### PR TITLE
Prepare for release v2020.6.26

### DIFF
--- a/docs/CHANGELOG-v2020.6.26.md
+++ b/docs/CHANGELOG-v2020.6.26.md
@@ -1,0 +1,257 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2020.6.26
+    name: Changelog-v2020.6.26
+    parent: welcome
+    weight: 20200626
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.6.26/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.6.26/
+---
+
+# Stash v2020.6.26
+
+
+## [appscode-cloud/apimachinery](https://github.com/appscode-cloud/apimachinery)
+
+### [v0.10.0-alpha.4](https://github.com/appscode-cloud/apimachinery/releases/tag/v0.10.0-alpha.4)
+
+- [28d53699](https://github.com/appscode-cloud/apimachinery/commit/28d53699) Update update-release-tracker.sh
+- [34624044](https://github.com/appscode-cloud/apimachinery/commit/34624044) Update update-release-tracker.sh
+- [5f5de63c](https://github.com/appscode-cloud/apimachinery/commit/5f5de63c) Fix openapi path (#24)
+- [6e0ad5f8](https://github.com/appscode-cloud/apimachinery/commit/6e0ad5f8) Add script to update release tracker on pr merge (#23)
+- [cbf9b376](https://github.com/appscode-cloud/apimachinery/commit/cbf9b376) Update .kodiak.toml
+- [d12b3d4b](https://github.com/appscode-cloud/apimachinery/commit/d12b3d4b) Update to Kubernetes v1.18.3 (#21)
+- [1956a312](https://github.com/appscode-cloud/apimachinery/commit/1956a312) Update to Kubernetes v1.18.3
+
+
+
+## [appscode-cloud/catalog](https://github.com/appscode-cloud/catalog)
+
+### [v2020.6.26](https://github.com/appscode-cloud/catalog/releases/tag/v2020.6.26)
+
+
+
+
+## [appscode-cloud/cli](https://github.com/appscode-cloud/cli)
+
+### [v0.10.0-alpha.4](https://github.com/appscode-cloud/cli/releases/tag/v0.10.0-alpha.4)
+
+- [15544a5](https://github.com/appscode-cloud/cli/commit/15544a5) Prepare for release v0.10.0-alpha.4 (#1)
+- [66b3b46](https://github.com/appscode-cloud/cli/commit/66b3b46) Shorten command name for cli (#24)
+- [b913cfc](https://github.com/appscode-cloud/cli/commit/b913cfc) Add workflow to update docs (#23)
+- [1881c64](https://github.com/appscode-cloud/cli/commit/1881c64) Update update-release-tracker.sh
+- [0548bdc](https://github.com/appscode-cloud/cli/commit/0548bdc) Update update-release-tracker.sh
+- [b1b28ff](https://github.com/appscode-cloud/cli/commit/b1b28ff) Use GITHUB_BASE_REF to detect target branch
+- [1e16b99](https://github.com/appscode-cloud/cli/commit/1e16b99) Add script to update release tracker on pr merge (#21)
+- [f91bf33](https://github.com/appscode-cloud/cli/commit/f91bf33) Make release non-draft
+- [d29bdb6](https://github.com/appscode-cloud/cli/commit/d29bdb6) Update .kodiak.toml
+- [b727108](https://github.com/appscode-cloud/cli/commit/b727108) Update to Kubernetes v1.18.3 (#20)
+- [f3f03aa](https://github.com/appscode-cloud/cli/commit/f3f03aa) Update to Kubernetes v1.18.3
+- [bcd7c5e](https://github.com/appscode-cloud/cli/commit/bcd7c5e) Create .kodiak.toml
+- [9882aa2](https://github.com/appscode-cloud/cli/commit/9882aa2) Add blank line after license header (#19)
+- [7774218](https://github.com/appscode-cloud/cli/commit/7774218) Update dev scripts (#18)
+- [38eb35c](https://github.com/appscode-cloud/cli/commit/38eb35c) Run unit tests against SRC_PKGS
+- [526949c](https://github.com/appscode-cloud/cli/commit/526949c) Update to Kubernetes v1.18.3 (#17)
+- [fc3e6c5](https://github.com/appscode-cloud/cli/commit/fc3e6c5) Update crazy-max/ghaction-docker-buildx flag
+- [3943575](https://github.com/appscode-cloud/cli/commit/3943575) Trigger the workflow on push or pull request
+
+
+
+## [appscode-cloud/installer](https://github.com/appscode-cloud/installer)
+
+### [v0.10.0-alpha.4](https://github.com/appscode-cloud/installer/releases/tag/v0.10.0-alpha.4)
+
+- [7b0bd5e](https://github.com/appscode-cloud/installer/commit/7b0bd5e) Prepare for release v0.10.0-alpha.4 (#1)
+- [15d1594](https://github.com/appscode-cloud/installer/commit/15d1594) Fix Stash Enterprise installer (#70)
+- [31c9dcc](https://github.com/appscode-cloud/installer/commit/31c9dcc) Tag chart and app version as string for yq (#69)
+- [1782049](https://github.com/appscode-cloud/installer/commit/1782049) Update links (#68)
+- [634da4d](https://github.com/appscode-cloud/installer/commit/634da4d) Update update-release-tracker.sh
+- [1155610](https://github.com/appscode-cloud/installer/commit/1155610) Update update-release-tracker.sh
+- [1b10b5e](https://github.com/appscode-cloud/installer/commit/1b10b5e) Add script to update release tracker on pr merge (#67)
+- [ce0b28e](https://github.com/appscode-cloud/installer/commit/ce0b28e) Update release workflow
+- [c3ac668](https://github.com/appscode-cloud/installer/commit/c3ac668) Update ci.yml
+- [98bad7e](https://github.com/appscode-cloud/installer/commit/98bad7e) Add Stash Enterprise chart (#63)
+- [73f52a6](https://github.com/appscode-cloud/installer/commit/73f52a6) Add commands to update chart (#65)
+- [0dc7f91](https://github.com/appscode-cloud/installer/commit/0dc7f91) Fix chart release process (#64)
+- [0d5c4e1](https://github.com/appscode-cloud/installer/commit/0d5c4e1) Update .kodiak.toml
+- [3b53e64](https://github.com/appscode-cloud/installer/commit/3b53e64) Update to Kubernetes v1.18.3 (#58)
+- [43c5dbe](https://github.com/appscode-cloud/installer/commit/43c5dbe) Update to Kubernetes v1.18.3
+- [b9e784c](https://github.com/appscode-cloud/installer/commit/b9e784c) Create .kodiak.toml
+- [b30b3b0](https://github.com/appscode-cloud/installer/commit/b30b3b0) Merge pull request #57 from stashed/psp
+- [1b89401](https://github.com/appscode-cloud/installer/commit/1b89401) Disable apparmor and seccomp by default
+- [6bed1aa](https://github.com/appscode-cloud/installer/commit/6bed1aa) Pass psp names for the jobs through flag
+- [bd35d81](https://github.com/appscode-cloud/installer/commit/bd35d81) Always use baseline psp for stash
+- [4e3474a](https://github.com/appscode-cloud/installer/commit/4e3474a) Add RBAC permission for generic-garbage-collector (#56)
+- [be006f6](https://github.com/appscode-cloud/installer/commit/be006f6) Permit configmap list/watch -ing for delegated authentication checking (#55)
+- [5685c15](https://github.com/appscode-cloud/installer/commit/5685c15) Update dependencies
+- [8b7b805](https://github.com/appscode-cloud/installer/commit/8b7b805) Update dependencies
+- [d2b2b09](https://github.com/appscode-cloud/installer/commit/d2b2b09) Generate both v1beta1 and v1 CRD YAML (#54)
+- [7fbcb29](https://github.com/appscode-cloud/installer/commit/7fbcb29) Update to Kubernetes v1.18.3 (#53)
+- [88e5e8c](https://github.com/appscode-cloud/installer/commit/88e5e8c) Use Go 1.14.3
+- [8e56cb1](https://github.com/appscode-cloud/installer/commit/8e56cb1) Trigger build on push to only master branch
+- [562caf8](https://github.com/appscode-cloud/installer/commit/562caf8) Use recommended kubernetes app labels (#52)
+- [cc55e5a](https://github.com/appscode-cloud/installer/commit/cc55e5a) Trigger the workflow on push or pull request
+- [fd8acf5](https://github.com/appscode-cloud/installer/commit/fd8acf5) Update chart readme
+- [672f37e](https://github.com/appscode-cloud/installer/commit/672f37e) Show examples in chart readme
+- [39f4ca1](https://github.com/appscode-cloud/installer/commit/39f4ca1) Auto generate chart readme file (#50)
+- [47f4250](https://github.com/appscode-cloud/installer/commit/47f4250) Update release.yml
+- [b68d9cb](https://github.com/appscode-cloud/installer/commit/b68d9cb) Cleanup newlines
+- [20d51b0](https://github.com/appscode-cloud/installer/commit/20d51b0) Reformat stash chart template (#49)
+- [65f8bee](https://github.com/appscode-cloud/installer/commit/65f8bee) Use kubectl v1.16 as cleaner (#48)
+- [85a7cfd](https://github.com/appscode-cloud/installer/commit/85a7cfd) Rename prometheus.io/coreos-operator to prometheus.io/operator (#47)
+- [b042def](https://github.com/appscode-cloud/installer/commit/b042def) Move apireg annotation to operator pod (#46)
+- [a543953](https://github.com/appscode-cloud/installer/commit/a543953) Various cleanup (#44)
+- [b6e2bec](https://github.com/appscode-cloud/installer/commit/b6e2bec) Fix helm install --wait flag (#42)
+- [806aada](https://github.com/appscode-cloud/installer/commit/806aada) Do not harcode namespace (#40)
+
+
+
+## [appscode-cloud/postgres](https://github.com/appscode-cloud/postgres)
+
+### [9.6-v1](https://github.com/appscode-cloud/postgres/releases/tag/9.6-v1)
+
+- [f06865b](https://github.com/appscode-cloud/postgres/commit/f06865b) Prepare for release 9.6-v1 (#5)
+- [388ddee](https://github.com/appscode-cloud/postgres/commit/388ddee) Add commands to update chart version (#71)
+- [875c1f0](https://github.com/appscode-cloud/postgres/commit/875c1f0) [cherry-pick] Update update-release-tracker.sh (#70)
+- [0e71e2d](https://github.com/appscode-cloud/postgres/commit/0e71e2d) [cherry-pick] Update update-release-tracker.sh (#65)
+- [bbfac61](https://github.com/appscode-cloud/postgres/commit/bbfac61) [cherry-pick] Update release.yml (#55) (#60)
+- [986d0a7](https://github.com/appscode-cloud/postgres/commit/986d0a7) [cherry-pick] Add script to update release tracker on pr merge (#49) (#54)
+- [6edaf36](https://github.com/appscode-cloud/postgres/commit/6edaf36) [cherry-pick] Remove /cherry-pick from cherry picked prs (#43) (#48)
+- [6743dbe](https://github.com/appscode-cloud/postgres/commit/6743dbe) [cherry-pick] Add workflow to cherry pick commits to master (#37) (#42)
+- [fb4f222](https://github.com/appscode-cloud/postgres/commit/fb4f222) Fix chart release process (#36)
+- [b5ddf5f](https://github.com/appscode-cloud/postgres/commit/b5ddf5f) Update .kodiak.toml
+- [7951787](https://github.com/appscode-cloud/postgres/commit/7951787) Fix waitForDBReady() logic + Make timeout configurable (#35)
+- [e7bb18f](https://github.com/appscode-cloud/postgres/commit/e7bb18f) Create .kodiak.toml
+- [60acc09](https://github.com/appscode-cloud/postgres/commit/60acc09) Merge pull request Allow overriding secret keys from AppBinding #33
+- [aaff7fb](https://github.com/appscode-cloud/postgres/commit/aaff7fb) Fix typos (#32)
+- [568f584](https://github.com/appscode-cloud/postgres/commit/568f584) Update to Kubernetes v1.18.3 (#34)
+- [098bb78](https://github.com/appscode-cloud/postgres/commit/098bb78) Update crazy-max/ghaction-docker-buildx flag
+- [4385362](https://github.com/appscode-cloud/postgres/commit/4385362) function-args: add pg-back-cmd option
+- [7cd065c](https://github.com/appscode-cloud/postgres/commit/7cd065c) Trigger the workflow on push or pull request
+- [b63e3e5](https://github.com/appscode-cloud/postgres/commit/b63e3e5) Auto generate chart readme file
+- [dea1a41](https://github.com/appscode-cloud/postgres/commit/dea1a41) Correctly mark optional fields
+- [efc4283](https://github.com/appscode-cloud/postgres/commit/efc4283) Add openapi v3 schema for values file (#27)
+
+
+### [10.2-v1](https://github.com/appscode-cloud/postgres/releases/tag/10.2-v1)
+
+- [1f604fc](https://github.com/appscode-cloud/postgres/commit/1f604fc) Prepare for release 10.2-v1 (#1)
+- [27604a5](https://github.com/appscode-cloud/postgres/commit/27604a5) Add commands to update chart version (#71)
+- [bac456e](https://github.com/appscode-cloud/postgres/commit/bac456e) [cherry-pick] Update update-release-tracker.sh (#66)
+- [a50a3a8](https://github.com/appscode-cloud/postgres/commit/a50a3a8) [cherry-pick] Update update-release-tracker.sh (#61)
+- [2d792b7](https://github.com/appscode-cloud/postgres/commit/2d792b7) [cherry-pick] Update release.yml (#55) (#56)
+- [c4603ac](https://github.com/appscode-cloud/postgres/commit/c4603ac) [cherry-pick] Add script to update release tracker on pr merge (#49) (#50)
+- [0c08bad](https://github.com/appscode-cloud/postgres/commit/0c08bad) [cherry-pick] Remove /cherry-pick from cherry picked prs (#43) (#44)
+- [6764fe3](https://github.com/appscode-cloud/postgres/commit/6764fe3) [cherry-pick] Add workflow to cherry pick commits to master (#37) (#38)
+- [826f678](https://github.com/appscode-cloud/postgres/commit/826f678) Fix chart release process (#36)
+- [e5146e3](https://github.com/appscode-cloud/postgres/commit/e5146e3) Update .kodiak.toml
+- [d4d68ef](https://github.com/appscode-cloud/postgres/commit/d4d68ef) Fix waitForDBReady() logic + Make timeout configurable (#35)
+- [78fa0ac](https://github.com/appscode-cloud/postgres/commit/78fa0ac) Create .kodiak.toml
+- [23cfc56](https://github.com/appscode-cloud/postgres/commit/23cfc56) Merge pull request Allow overriding secret keys from AppBinding #33
+- [0cdc7c9](https://github.com/appscode-cloud/postgres/commit/0cdc7c9) Fix typos (#32)
+- [a148ace](https://github.com/appscode-cloud/postgres/commit/a148ace) Update to Kubernetes v1.18.3 (#34)
+- [db126f4](https://github.com/appscode-cloud/postgres/commit/db126f4) Update crazy-max/ghaction-docker-buildx flag
+- [854a522](https://github.com/appscode-cloud/postgres/commit/854a522) function-args: add pg-back-cmd option
+- [e64e5b0](https://github.com/appscode-cloud/postgres/commit/e64e5b0) Trigger the workflow on push or pull request
+- [d667589](https://github.com/appscode-cloud/postgres/commit/d667589) Auto generate chart readme file
+- [f562d87](https://github.com/appscode-cloud/postgres/commit/f562d87) Correctly mark optional fields
+- [3c5b7bc](https://github.com/appscode-cloud/postgres/commit/3c5b7bc) Add openapi v3 schema for values file (#27)
+
+
+### [10.6-v1](https://github.com/appscode-cloud/postgres/releases/tag/10.6-v1)
+
+- [d94adf3](https://github.com/appscode-cloud/postgres/commit/d94adf3) Prepare for release 10.6-v1 (#2)
+- [8ae0673](https://github.com/appscode-cloud/postgres/commit/8ae0673) Add commands to update chart version (#71)
+- [44bf83d](https://github.com/appscode-cloud/postgres/commit/44bf83d) [cherry-pick] Update update-release-tracker.sh (#67)
+- [e20f246](https://github.com/appscode-cloud/postgres/commit/e20f246) [cherry-pick] Update update-release-tracker.sh (#62)
+- [0120b84](https://github.com/appscode-cloud/postgres/commit/0120b84) [cherry-pick] Update release.yml (#55) (#57)
+- [ddfc26d](https://github.com/appscode-cloud/postgres/commit/ddfc26d) [cherry-pick] Add script to update release tracker on pr merge (#49) (#51)
+- [bde7425](https://github.com/appscode-cloud/postgres/commit/bde7425) [cherry-pick] Remove /cherry-pick from cherry picked prs (#43) (#45)
+- [00a5c97](https://github.com/appscode-cloud/postgres/commit/00a5c97) [cherry-pick] Add workflow to cherry pick commits to master (#37) (#39)
+- [1720053](https://github.com/appscode-cloud/postgres/commit/1720053) Fix chart release process (#36)
+- [f67d343](https://github.com/appscode-cloud/postgres/commit/f67d343) Update .kodiak.toml
+- [6f70879](https://github.com/appscode-cloud/postgres/commit/6f70879) Fix waitForDBReady() logic + Make timeout configurable (#35)
+- [39a7fc4](https://github.com/appscode-cloud/postgres/commit/39a7fc4) Create .kodiak.toml
+- [4ba7a9f](https://github.com/appscode-cloud/postgres/commit/4ba7a9f) Merge pull request Allow overriding secret keys from AppBinding #33
+- [804433c](https://github.com/appscode-cloud/postgres/commit/804433c) Fix typos (#32)
+- [42e792f](https://github.com/appscode-cloud/postgres/commit/42e792f) Update to Kubernetes v1.18.3 (#34)
+- [b15f604](https://github.com/appscode-cloud/postgres/commit/b15f604) Update crazy-max/ghaction-docker-buildx flag
+- [288b3ea](https://github.com/appscode-cloud/postgres/commit/288b3ea) function-args: add pg-back-cmd option
+- [d0ff5d9](https://github.com/appscode-cloud/postgres/commit/d0ff5d9) Trigger the workflow on push or pull request
+- [23e9f4a](https://github.com/appscode-cloud/postgres/commit/23e9f4a) Auto generate chart readme file
+- [9431b3a](https://github.com/appscode-cloud/postgres/commit/9431b3a) Correctly mark optional fields
+- [0fe49c0](https://github.com/appscode-cloud/postgres/commit/0fe49c0) Add openapi v3 schema for values file (#27)
+
+
+### [11.1-v1](https://github.com/appscode-cloud/postgres/releases/tag/11.1-v1)
+
+- [156cc55](https://github.com/appscode-cloud/postgres/commit/156cc55) Prepare for release 11.1-v1 (#3)
+- [7bf38e7](https://github.com/appscode-cloud/postgres/commit/7bf38e7) Add commands to update chart version (#71)
+- [6ecb8bc](https://github.com/appscode-cloud/postgres/commit/6ecb8bc) [cherry-pick] Update update-release-tracker.sh (#68)
+- [526e335](https://github.com/appscode-cloud/postgres/commit/526e335) [cherry-pick] Update update-release-tracker.sh (#63)
+- [e5fff5c](https://github.com/appscode-cloud/postgres/commit/e5fff5c) [cherry-pick] Update release.yml (#55) (#58)
+- [81f3b07](https://github.com/appscode-cloud/postgres/commit/81f3b07) [cherry-pick] Add script to update release tracker on pr merge (#49) (#52)
+- [5ba7bd6](https://github.com/appscode-cloud/postgres/commit/5ba7bd6) [cherry-pick] Remove /cherry-pick from cherry picked prs (#43) (#46)
+- [12adf32](https://github.com/appscode-cloud/postgres/commit/12adf32) [cherry-pick] Add workflow to cherry pick commits to master (#37) (#40)
+- [cac2584](https://github.com/appscode-cloud/postgres/commit/cac2584) Fix chart release process (#36)
+- [fadf4ec](https://github.com/appscode-cloud/postgres/commit/fadf4ec) Update .kodiak.toml
+- [46669d7](https://github.com/appscode-cloud/postgres/commit/46669d7) Fix waitForDBReady() logic + Make timeout configurable (#35)
+- [338ab6c](https://github.com/appscode-cloud/postgres/commit/338ab6c) Create .kodiak.toml
+- [3acfe21](https://github.com/appscode-cloud/postgres/commit/3acfe21) Merge pull request Allow overriding secret keys from AppBinding #33
+- [1c5cd1c](https://github.com/appscode-cloud/postgres/commit/1c5cd1c) Fix typos (#32)
+- [5c09c1b](https://github.com/appscode-cloud/postgres/commit/5c09c1b) Update to Kubernetes v1.18.3 (#34)
+- [ed629e5](https://github.com/appscode-cloud/postgres/commit/ed629e5) Update crazy-max/ghaction-docker-buildx flag
+- [0b8cd43](https://github.com/appscode-cloud/postgres/commit/0b8cd43) function-args: add pg-back-cmd option
+- [161a325](https://github.com/appscode-cloud/postgres/commit/161a325) Trigger the workflow on push or pull request
+- [062a652](https://github.com/appscode-cloud/postgres/commit/062a652) Auto generate chart readme file
+- [ec94eac](https://github.com/appscode-cloud/postgres/commit/ec94eac) Correctly mark optional fields
+- [5656c62](https://github.com/appscode-cloud/postgres/commit/5656c62) Add openapi v3 schema for values file (#27)
+
+
+### [11.2-v1](https://github.com/appscode-cloud/postgres/releases/tag/11.2-v1)
+
+- [c5121bf](https://github.com/appscode-cloud/postgres/commit/c5121bf) Prepare for release 11.2-v1 (#4)
+- [03fd7d3](https://github.com/appscode-cloud/postgres/commit/03fd7d3) Add commands to update chart version (#71)
+- [a48d053](https://github.com/appscode-cloud/postgres/commit/a48d053) [cherry-pick] Update update-release-tracker.sh (#69)
+- [7ac5c11](https://github.com/appscode-cloud/postgres/commit/7ac5c11) [cherry-pick] Update update-release-tracker.sh (#64)
+- [ecf236a](https://github.com/appscode-cloud/postgres/commit/ecf236a) [cherry-pick] Update release.yml (#55) (#59)
+- [013242e](https://github.com/appscode-cloud/postgres/commit/013242e) [cherry-pick] Add script to update release tracker on pr merge (#49) (#53)
+- [c8b360b](https://github.com/appscode-cloud/postgres/commit/c8b360b) [cherry-pick] Remove /cherry-pick from cherry picked prs (#43) (#47)
+- [2503240](https://github.com/appscode-cloud/postgres/commit/2503240) [cherry-pick] Add workflow to cherry pick commits to master (#37) (#41)
+- [3f7525c](https://github.com/appscode-cloud/postgres/commit/3f7525c) Fix chart release process (#36)
+- [4afcc41](https://github.com/appscode-cloud/postgres/commit/4afcc41) Update .kodiak.toml
+- [861eaa3](https://github.com/appscode-cloud/postgres/commit/861eaa3) Fix waitForDBReady() logic + Make timeout configurable (#35)
+- [85ea8d6](https://github.com/appscode-cloud/postgres/commit/85ea8d6) Create .kodiak.toml
+- [f240c25](https://github.com/appscode-cloud/postgres/commit/f240c25) Merge pull request Allow overriding secret keys from AppBinding #33
+- [4e5898f](https://github.com/appscode-cloud/postgres/commit/4e5898f) Fix typos (#32)
+- [b4b61cf](https://github.com/appscode-cloud/postgres/commit/b4b61cf) Update to Kubernetes v1.18.3 (#34)
+- [62f2714](https://github.com/appscode-cloud/postgres/commit/62f2714) Update crazy-max/ghaction-docker-buildx flag
+- [962df30](https://github.com/appscode-cloud/postgres/commit/962df30) function-args: add pg-back-cmd option
+- [55e792e](https://github.com/appscode-cloud/postgres/commit/55e792e) Trigger the workflow on push or pull request
+- [66b4a51](https://github.com/appscode-cloud/postgres/commit/66b4a51) Auto generate chart readme file
+- [dd606bf](https://github.com/appscode-cloud/postgres/commit/dd606bf) Correctly mark optional fields
+- [efe4799](https://github.com/appscode-cloud/postgres/commit/efe4799) Add openapi v3 schema for values file (#27)
+
+
+
+## [appscode-cloud/stash](https://github.com/appscode-cloud/stash)
+
+### [v0.10.0-alpha.4](https://github.com/appscode-cloud/stash/releases/tag/v0.10.0-alpha.4)
+
+- [bdb915ab](https://github.com/appscode-cloud/stash/commit/bdb915ab) Prepare for release v0.10.0-alpha.4 (#1)
+- [9fa95666](https://github.com/appscode-cloud/stash/commit/9fa95666) Add workflow to update docs (#1136)
+- [95a62a95](https://github.com/appscode-cloud/stash/commit/95a62a95) Update update-release-tracker.sh
+- [379c90d5](https://github.com/appscode-cloud/stash/commit/379c90d5) Update update-release-tracker.sh
+- [cd0a70ee](https://github.com/appscode-cloud/stash/commit/cd0a70ee) Use GITHUB_BASE_REF to detect target branch
+- [e27c5f66](https://github.com/appscode-cloud/stash/commit/e27c5f66) Add script to update release tracker on pr merge (#1132)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.6.26
Release-tracker: https://github.com/appscodelabs/release-automaton-demo/pull/6
Signed-off-by: 1gtm <1gtm@appscode.com>