### PR TITLE
Prepare for release v2026.6.19

### DIFF
--- a/docs/platform/CHANGELOG-v2026.6.19.md
+++ b/docs/platform/CHANGELOG-v2026.6.19.md
@@ -1,0 +1,102 @@
+---
+title: Changelog | ACE
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-ace-v2026.6.19
+    name: Changelog-v2026.6.19
+    parent: welcome
+    weight: 20260619
+product_name: ace
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.6.19/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.6.19/
+---
+
+# ACE v2026.6.19 (2026-06-21)
+
+
+## [appscode-cloud/b3](https://github.com/appscode-cloud/b3)
+
+### [v2026.6.19](https://github.com/appscode-cloud/b3/releases/tag/v2026.6.19)
+
+
+
+
+## [appscode-cloud/installer](https://github.com/appscode-cloud/installer)
+
+### [v2026.6.19](https://github.com/appscode-cloud/installer/releases/tag/v2026.6.19)
+
+
+
+
+## [appscode-cloud/ui-wizards](https://github.com/appscode-cloud/ui-wizards)
+
+### [v0.35.0](https://github.com/appscode-cloud/ui-wizards/releases/tag/v0.35.0)
+
+- [0a9c4c10](https://github.com/appscode-cloud/ui-wizards/commit/0a9c4c104) Prepare for release v0.35.0 (#1062)
+
+
+
+## [appscode/website](https://github.com/appscode/website)
+
+### [v2026.6.19](https://github.com/appscode/website/releases/tag/v2026.6.19)
+
+- [01f7f216](https://github.com/appscode/website/commit/01f7f216) Prepare for release v2026.6.19 (#215)
+- [f184b71b](https://github.com/appscode/website/commit/f184b71b) Pin Node to 22.22.3 to fix firebase preview deploy auth (#216)
+
+
+
+## [kmodules/image-packer](https://github.com/kmodules/image-packer)
+
+### [v2026.6.19](https://github.com/kmodules/image-packer/releases/tag/v2026.6.19)
+
+- [d6091139](https://github.com/kmodules/image-packer/commit/d6091139) Prepare for release v2026.6.19 (#55)
+
+
+
+## [kmodules/resource-metadata](https://github.com/kmodules/resource-metadata)
+
+### [v0.47.0](https://github.com/kmodules/resource-metadata/releases/tag/v0.47.0)
+
+- [fcd907ae](https://github.com/kmodules/resource-metadata/commit/fcd907ae6) Prepare for release v0.47.0 (#650)
+- [85c67bcb](https://github.com/kmodules/resource-metadata/commit/85c67bcb0) Update to KubeDB and KubeStash v2026.6.19
+- [e86f70f4](https://github.com/kmodules/resource-metadata/commit/e86f70f4c) Resync kubedb & kubestash CRDs
+- [776d5e81](https://github.com/kmodules/resource-metadata/commit/776d5e816) Update KubeDB and KubeStash for v2026.6.18-rc.2
+- [25abe419](https://github.com/kmodules/resource-metadata/commit/25abe4197) Sync up missing editors
+- [a7af825c](https://github.com/kmodules/resource-metadata/commit/a7af825c9) Update kubedb & catalog CRDs
+- [4ac7c73a](https://github.com/kmodules/resource-metadata/commit/4ac7c73ae) Add `observability-cluster` clusterprofile (#646)
+- [05ae8ec7](https://github.com/kmodules/resource-metadata/commit/05ae8ec76) Fix documentdb & import kubedb crds (#648)
+- [791189ee](https://github.com/kmodules/resource-metadata/commit/791189ee6) Add documentdb in menu
+- [45589858](https://github.com/kmodules/resource-metadata/commit/455898580) Remove FerretDB support (#647)
+
+
+
+## [kubeops/installer](https://github.com/kubeops/installer)
+
+### [v2026.6.19](https://github.com/kubeops/installer/releases/tag/v2026.6.19)
+
+- [ed4648dd](https://github.com/kubeops/installer/commit/ed4648dd) Prepare for release v2026.6.19 (#490)
+
+
+
+## [kubeops/ui-server](https://github.com/kubeops/ui-server)
+
+### [v0.5.0](https://github.com/kubeops/ui-server/releases/tag/v0.5.0)
+
+
+
+
+## [kubepack/lib-app](https://github.com/kubepack/lib-app)
+
+### [v0.23.0](https://github.com/kubepack/lib-app/releases/tag/v0.23.0)
+
+- [c12c4ce7](https://github.com/kubepack/lib-app/commit/c12c4ce7b) Prepare for release v0.23.0 (#172)
+- [6840206e](https://github.com/kubepack/lib-app/commit/6840206e0) Update vulnerable dependencies (#171)
+- [6dcb8a92](https://github.com/kubepack/lib-app/commit/6dcb8a924) Remove FerretDB support (#169)
+
+
+
+


### PR DESCRIPTION
ProductLine: ACE
Release: v2026.6.19
Release-tracker: https://github.com/appscode-cloud/CHANGELOG/pull/75
Signed-off-by: 1gtm <1gtm@appscode.com>