### PR TITLE
docs: add extra ../ to all local refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install link checker
         run: |
-          curl -fsSL -o liche https://github.com/appscodelabs/liche/releases/download/v0.1.0/liche-linux-amd64
+          curl -fsSL -o liche https://github.com/appscodelabs/liche/releases/download/v0.2.0/liche-linux-amd64
           chmod +x liche
           sudo mv liche /usr/local/bin/liche
 
@@ -50,11 +50,11 @@ jobs:
 
       - name: Check links
         run: |
-          liche -r docs -d $(pwd) -c 10 -p -h -l -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$'
+          liche -r docs -d $(pwd) -c 10 -p -h -l -s -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$'
           max_retries=5
           retry_count=0
           while [ $retry_count -lt $max_retries ]; do
-            if liche -r docs -d $(pwd) -c 10 -p -h -l -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$'; then
+            if liche -r docs -d $(pwd) -c 10 -p -h -l -s -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$'; then
               echo "Link check passed"
               exit 0
             fi

--- a/docs/platform/README.md
+++ b/docs/platform/README.md
@@ -21,12 +21,12 @@ This page is the entry point for KubeDB Platform documentation.
 
 ## Core sections
 
-- [Selfhost Setup](./selfhost-setup/)
-- [Guides](./guides/)
+- [Selfhost Setup](../selfhost-setup/)
+- [Guides](../guides/)
 
 ## Contributor resources
 
-- [Contributing](./contributing.md)
-- [Support](./support.md)
+- [Contributing](../contributing.md)
+- [Support](../support.md)
 
-Use [Guides](./guides/) for day-to-day workflows, then continue to [Selfhost Setup](./selfhost-setup/) for deployment-specific instructions.
+Use [Guides](../guides/) for day-to-day workflows, then continue to [Selfhost Setup](../selfhost-setup/) for deployment-specific instructions.

--- a/docs/platform/guides/README.md
+++ b/docs/platform/guides/README.md
@@ -19,14 +19,14 @@ This section contains practical, task-oriented guides for operating and managing
 
 ## Guide categories
 
-- [Account Management](./account-management/)
-- [Billing and Usage Guide](./billing-and-usage-guide/)
-- [Cluster Management](./cluster-management/)
-- [Database Management](./database-management/)
-- [Get Started](./get-started/)
-- [Integrations](./integrations/)
-- [License Management](./license-management/)
+- [Account Management](../account-management/)
+- [Billing and Usage Guide](../billing-and-usage-guide/)
+- [Cluster Management](../cluster-management/)
+- [Database Management](../database-management/)
+- [Get Started](../get-started/)
+- [Integrations](../integrations/)
+- [License Management](../license-management/)
 
 ## Recommended path
 
-For first-time users, start with [Get Started](./get-started/) and then move to the specific management areas relevant to your workflow.
+For first-time users, start with [Get Started](../get-started/) and then move to the specific management areas relevant to your workflow.

--- a/docs/platform/guides/account-management/site-administration/client-org.md
+++ b/docs/platform/guides/account-management/site-administration/client-org.md
@@ -21,9 +21,9 @@ A Client Organization provides logical separation between different clients shar
 
 Before creating a Client Organization, make sure the following are already in place:
 
-- **A Hub cluster is set up** — See [Create Hub & Spoke](../../cluster-management/hub-ui/create.md) for the full setup guide.
+- **A Hub cluster is set up** — See [Create Hub & Spoke](../../../cluster-management/hub-ui/create.md) for the full setup guide.
 - **A Spoke cluster is connected to the Hub** — The Spoke must be linked and accepted by the Hub administrator.
-- **The Spoke cluster is licensed** — A valid license certificate must be applied to the Spoke. Without it, database features remain in a **Warning** state and the organization cannot be created. See [License Management](../../cluster-management/hub-ui/license-management.md) for details.
+- **The Spoke cluster is licensed** — A valid license certificate must be applied to the Spoke. Without it, database features remain in a **Warning** state and the organization cannot be created. See [License Management](../../../cluster-management/hub-ui/license-management.md) for details.
 
 > ⚠️ Always perform these steps from an **Organization/Work account**. Personal accounts do not support Hub-Spoke features.
 

--- a/docs/platform/guides/billing-and-usage-guide/overview.md
+++ b/docs/platform/guides/billing-and-usage-guide/overview.md
@@ -54,7 +54,7 @@ What you’ll see in the Billable table
   - Usage covered by the **30‑day free contract** when there’s no paid contract for the selected product.
 
 **How to influence these numbers:**
-  - Cluster mode (`PROD` vs `NON‑PROD`) and namespace trials are configured in Cost Management: [Cost Management](./cost-management.md)
+  - Cluster mode (`PROD` vs `NON‑PROD`) and namespace trials are configured in Cost Management: [Cost Management](../cost-management.md)
   - Contract behavior (`paid` vs. `30‑day free` when none exists) is described here: [Contract docs](http://appscode.com/docs/en/guides/license-management/contract.html)
 
 **For more details, please contact** [AppsCode administrators](https://appscode.com/contact/).

--- a/docs/platform/guides/client-organization/add-cluster-to-existing-client-organization.md
+++ b/docs/platform/guides/client-organization/add-cluster-to-existing-client-organization.md
@@ -12,32 +12,32 @@ section_menu_id: guides
 
 # Add a Cluster to an Existing Client Organization
 
-You can assign additional clusters to a client organization after it has been created. The **Add Cluster** wizard reuses the same **Gateway Configuration** and **Telemetry Configuration** steps as the [Create Client Organization](./create-client-organization.md) wizard.
+You can assign additional clusters to a client organization after it has been created. The **Add Cluster** wizard reuses the same **Gateway Configuration** and **Telemetry Configuration** steps as the [Create Client Organization](../create-client-organization.md) wizard.
 
 ## Open the Client Organization
 
 Go to **Site Administration → Client Organizations** and click the organization's **Name** in the list to open its details.
 
-![Client Organizations list — click an organization's name to open its details](./images/client-org-overview.png)
+![Client Organizations list — click an organization's name to open its details](.././images/client-org-overview.png)
 
 ## Find the Add Cluster option
 
 On the organization's details page, the **Clusters** section lists the clusters already assigned to the organization. Click **Add Cluster** in the top-right of that section to start the wizard.
 
-![Client organization details page — the Clusters section with the Add Cluster button](./images/client-org-details.png)
+![Client organization details page — the Clusters section with the Add Cluster button](.././images/client-org-details.png)
 
 ## Step 1: Select Cluster
 
 In the first step of the **Add Cluster** wizard, choose the cluster to assign and optionally tune where its database workloads are scheduled.
 
-![Add Cluster wizard — Select Cluster step with hub cluster, spoke cluster, and DB nodepool](./images/add-cluster-to-existing-client-org.png)
+![Add Cluster wizard — Select Cluster step with hub cluster, spoke cluster, and DB nodepool](.././images/add-cluster-to-existing-client-org.png)
 
 - **Hub Cluster** *(required)* — the management (hub) cluster for this assignment.
 - **Spoke Cluster** *(required)* — the spoke cluster where the organization's databases run.
 - **Configure DB Nodepool** *(optional)* — key/value labels used to target specific nodes for database workloads.
 - **Tolerations** *(optional)* — add tolerations so workloads can be scheduled onto tainted nodes. Each toleration takes an **Effect**, **Key**, **Operator**, and **Value**.
 
-![Add Cluster wizard — Select Cluster step with DB nodepool and tolerations expanded](./images/add-cluster-to-existing-client-org-2.png)
+![Add Cluster wizard — Select Cluster step with DB nodepool and tolerations expanded](.././images/add-cluster-to-existing-client-org-2.png)
 
 Click **Next** to continue.
 
@@ -45,7 +45,7 @@ Click **Next** to continue.
 
 After selecting the cluster, the wizard continues with the same **Gateway Configuration** and **Telemetry Configuration** steps used when creating a client organization:
 
-- [Gateway Configuration](./create-client-organization.md#step-3-gateway-configuration) — choose a shared or dedicated gateway.
-- [Telemetry Configuration](./create-client-organization.md#step-4-telemetry-configuration) — configure log and metrics retention.
+- [Gateway Configuration](../create-client-organization.md#step-3-gateway-configuration) — choose a shared or dedicated gateway.
+- [Telemetry Configuration](../create-client-organization.md#step-4-telemetry-configuration) — configure log and metrics retention.
 
 Configure them as needed, then finish to add the cluster to the organization. The new cluster then appears in the **Clusters** section of the organization's details page.

--- a/docs/platform/guides/client-organization/create-client-organization.md
+++ b/docs/platform/guides/client-organization/create-client-organization.md
@@ -25,7 +25,7 @@ The wizard has four steps, shown on the right side of the form:
 
 Enter the organization details and choose its administrator.
 
-![Create Client Organization wizard — Step 1, User Information form with organization name, custom annotations, organization admin, and visibility](./images/create-client-organization.png)
+![Create Client Organization wizard — Step 1, User Information form with organization name, custom annotations, organization admin, and visibility](.././images/create-client-organization.png)
 
 - **Organization Name** *(required)* — used to provision the three namespaces (`orgName`, `orgName-gw`, and `orgName-monitoring`).
 - **Organization Display Name** — a friendly name shown in the UI.
@@ -42,7 +42,7 @@ Click **Next** to continue.
 
 Assign the organization to a hub and spoke cluster, and optionally tune where its database workloads are scheduled.
 
-![Create Client Organization wizard — Step 2, Select Cluster with hub cluster, spoke cluster, DB nodepool, and tolerations](./images/create-client-organization-2.png)
+![Create Client Organization wizard — Step 2, Select Cluster with hub cluster, spoke cluster, DB nodepool, and tolerations](.././images/create-client-organization-2.png)
 
 - **Hub Cluster** *(required)* — the management (hub) cluster for this organization.
 - **Spoke Cluster** *(required)* — the spoke cluster where the organization's databases run.
@@ -59,19 +59,19 @@ Choose how the organization exposes its workloads. There are two top-level optio
 
 Select **Use Shared Gateway** to reuse the platform's shared gateway. No additional gateway configuration is required.
 
-![Create Client Organization wizard — Step 3, Use Shared Gateway selected with no extra configuration](./images/use-shared-gateway.png)
+![Create Client Organization wizard — Step 3, Use Shared Gateway selected with no extra configuration](.././images/use-shared-gateway.png)
 
 ### Use Dedicated Gateway
 
 Select **Use Dedicated Gateway** to give the organization its own gateway. Then pick a **Dedicated Gateway Type**.
 
-![Create Client Organization wizard — Step 3, Use Dedicated Gateway selected with the dedicated gateway type options](./images/use-dedicated-gateway.png)
+![Create Client Organization wizard — Step 3, Use Dedicated Gateway selected with the dedicated gateway type options](.././images/use-dedicated-gateway.png)
 
 #### Use Existing Gateway
 
 Choose **Use Existing Gateway** and select a **Gateway Preset Config** to reuse an already-defined gateway configuration.
 
-![Create Client Organization wizard — dedicated gateway using an existing gateway preset config](./images/use-existing-gateway.png)
+![Create Client Organization wizard — dedicated gateway using an existing gateway preset config](.././images/use-existing-gateway.png)
 
 #### Use Custom Gateway
 
@@ -79,11 +79,11 @@ Choose **Use Custom Gateway** to define the gateway yourself. Use **Can it be us
 
 **Preload From Existing One** — start from an existing **Gateway Preset Config**, then edit the pre-filled fields across the **In Cluster** (certificates and keys), **Envoy Service** (service type, external IP, traffic policy, ports, provisioner type), and **Infra** (DNS provider, host type, host/domain, TLS issuer) sections.
 
-![Create Client Organization wizard — custom dedicated gateway preloaded from an existing preset, showing In Cluster, Envoy Service, and Infra sections](./images/preload-existing-gateway.png)
+![Create Client Organization wizard — custom dedicated gateway preloaded from an existing preset, showing In Cluster, Envoy Service, and Infra sections](.././images/preload-existing-gateway.png)
 
 **Create New From Start** — build the gateway from scratch by filling in the same **In Cluster**, **Envoy Service**, and **Infra** sections with your own values.
 
-![Create Client Organization wizard — custom dedicated gateway created from scratch with empty In Cluster, Envoy Service, and Infra sections](./images/create-new-custom-gateway.png)
+![Create Client Organization wizard — custom dedicated gateway created from scratch with empty In Cluster, Envoy Service, and Infra sections](.././images/create-new-custom-gateway.png)
 
 Click **Next** to continue.
 
@@ -91,7 +91,7 @@ Click **Next** to continue.
 
 In the final step, configure the telemetry settings that will be applied to the organization's `orgName-monitoring` namespace, then finish to create the client organization.
 
-![Create Client Organization wizard — Step 4, Telemetry Configuration with monitoring type, log retention, and metrics retention periods](./images/telemetry-configuration.png)
+![Create Client Organization wizard — Step 4, Telemetry Configuration with monitoring type, log retention, and metrics retention periods](.././images/telemetry-configuration.png)
 
 - **Select Monitoring Type** — choose the monitoring stack to provision for the organization.
 - **Logs** — set the **Retention Period** for collected logs.
@@ -106,4 +106,4 @@ Once created, the organization appears in the **Client Organizations** list and 
 
 ## Next steps
 
-- [Add a Cluster to an Existing Client Organization](./add-cluster-to-existing-client-organization.md) — assign additional clusters after the organization is created.
+- [Add a Cluster to an Existing Client Organization](../add-cluster-to-existing-client-organization.md) — assign additional clusters after the organization is created.

--- a/docs/platform/guides/client-organization/overview.md
+++ b/docs/platform/guides/client-organization/overview.md
@@ -35,5 +35,5 @@ Client organizations are managed from **Site Administration → Client Organizat
 
 ## Next steps
 
-- [Create a Client Organization](./create-client-organization.md) — a step-by-step walkthrough of the creation wizard.
-- [Add a Cluster to an Existing Client Organization](./add-cluster-to-existing-client-organization.md) — assign additional clusters after the organization is created.
+- [Create a Client Organization](../create-client-organization.md) — a step-by-step walkthrough of the creation wizard.
+- [Add a Cluster to an Existing Client Organization](../add-cluster-to-existing-client-organization.md) — assign additional clusters after the organization is created.

--- a/docs/platform/guides/cluster-management/add-cluster/create-vendor-managed.md
+++ b/docs/platform/guides/cluster-management/add-cluster/create-vendor-managed.md
@@ -13,6 +13,6 @@ section_menu_id: guides
 
 # Create Vendor Managed Clusters
 
-![Create vendor-managed cluster form showing cluster name, region, machine type, and cluster profile selection](../images/add_cluster/create-cluster-form.png)
+![Create vendor-managed cluster form showing cluster name, region, machine type, and cluster profile selection](../../images/add_cluster/create-cluster-form.png)
 
-![Creating cluster progress modal showing live status log](../images/add_cluster/create-cluster-progress.png)
+![Creating cluster progress modal showing live status log](../../images/add_cluster/create-cluster-progress.png)

--- a/docs/platform/guides/cluster-management/add-cluster/import-rancher-cluster.md
+++ b/docs/platform/guides/cluster-management/add-cluster/import-rancher-cluster.md
@@ -17,11 +17,11 @@ Importing a `Rancher-Managed` cluster requires a Rancher Type Credential and a R
 
 ## Create Rancher Type Credential
 
-Add a credential of type "Rancher" — see [Credentials Management](../../account-management/kubernetes/credentials.md#rancher).
+Add a credential of type "Rancher" — see [Credentials Management](../../../account-management/kubernetes/credentials.md#rancher).
 
 ## Create a Rancher Managed Organization
 
-Rancher clusters belong to Rancher Managed organizations, not personal accounts. Follow [Create a New Organization](../../account-management/orgs-members.md#create-a-new-organization) with these settings:
+Rancher clusters belong to Rancher Managed organizations, not personal accounts. Follow [Create a New Organization](../../../account-management/orgs-members.md#create-a-new-organization) with these settings:
 
 1. Set the organization's Origin to `Rancher Managed`.
 2. Provide the Rancher `API Endpoint` (found on the `Account & API Keys` page).
@@ -30,4 +30,4 @@ Rancher clusters belong to Rancher Managed organizations, not personal accounts.
 ## Import the Cluster
 
 1. Switch to the Rancher organization: in the [AppsCode Console](https://console.appscode.com), click your profile, choose `Switch Account`, and select the Rancher organization.
-2. Follow the standard import process in [Import Vendor Managed Clusters](import-vendor-managed.md).
+2. Follow the standard import process in [Import Vendor Managed Clusters](../import-vendor-managed.md).

--- a/docs/platform/guides/cluster-management/add-cluster/import-vendor-managed.md
+++ b/docs/platform/guides/cluster-management/add-cluster/import-vendor-managed.md
@@ -21,19 +21,19 @@ section_menu_id: guides
 
 ### Select Credential
 
-3. Choose a credential with permission to access and import the cluster, then click `Next`. To create one, use the `+Create Credential` button (see [Credentials](../../account-management/kubernetes/credentials.md)).
+3. Choose a credential with permission to access and import the cluster, then click `Next`. To create one, use the `+Create Credential` button (see [Credentials](../../../account-management/kubernetes/credentials.md)).
 
-![AWS credential form showing Access Key and Secret Key fields](../images/add_cluster/credential-aws.png)
+![AWS credential form showing Access Key and Secret Key fields](../../images/add_cluster/credential-aws.png)
 
-![DigitalOcean credential form showing Token field](../images/add_cluster/credential-digitalocean.png)
+![DigitalOcean credential form showing Token field](../../images/add_cluster/credential-digitalocean.png)
 
-![Azure credential form](../images/add_cluster/credential-azure.png)
+![Azure credential form](../../images/add_cluster/credential-azure.png)
 
-![GCP credential form showing Service Account JSON field](../images/add_cluster/credential-gcp.png)
+![GCP credential form showing Service Account JSON field](../../images/add_cluster/credential-gcp.png)
 
-![Hetzner credential form showing SSH Key Name and Token fields](../images/add_cluster/credential-hetzner.png)
+![Hetzner credential form showing SSH Key Name and Token fields](../../images/add_cluster/credential-hetzner.png)
 
-![KubeVirt credential form showing Kubeconfig YAML field](../images/add_cluster/credential-kubevirt.png)
+![KubeVirt credential form showing Kubeconfig YAML field](../../images/add_cluster/credential-kubevirt.png)
 
 ### Select Cluster
 
@@ -41,7 +41,7 @@ section_menu_id: guides
    - `Linode` / `Digital Ocean`: select the cluster directly.
    - `AKS` / `EKS` / `GKE`: choose the `Resource Group`, `Region`, or `Project`, then select the cluster.
 
-![EKS Select Cluster screen showing Region dropdown and cluster list table](../images/add_cluster/select-cluster-eks.png)
+![EKS Select Cluster screen showing Region dropdown and cluster list table](../../images/add_cluster/select-cluster-eks.png)
 
 ### Customize Features and Import
 

--- a/docs/platform/guides/cluster-management/add-cluster/overview.md
+++ b/docs/platform/guides/cluster-management/add-cluster/overview.md
@@ -16,9 +16,9 @@ Adding a Kubernetes cluster to the Platform Console takes two steps:
 
 ## Step 1: Select the Cluster
 
-- **Vendor-Managed:** [Import Vendor Managed Clusters](import-vendor-managed.md)
-- **Rancher-Managed:** [Import Rancher Managed Clusters](import-rancher-cluster.md)
-- **Self-Managed:** [Import Self-Managed Clusters](self-managed/import-self-managed.md)
+- **Vendor-Managed:** [Import Vendor Managed Clusters](../import-vendor-managed.md)
+- **Rancher-Managed:** [Import Rancher Managed Clusters](../import-rancher-cluster.md)
+- **Self-Managed:** [Import Self-Managed Clusters](../self-managed/import-self-managed.md)
 
 ## Step 2: Customize Features
 

--- a/docs/platform/guides/cluster-management/add-cluster/self-managed/import-public.md
+++ b/docs/platform/guides/cluster-management/add-cluster/self-managed/import-public.md
@@ -19,13 +19,13 @@ section_menu_id: guides
 
 2. In the `Self Managed` section, choose the public cluster option.
 
-![Add Cluster provider selection screen showing Vendor Managed and Self Managed sections with Public option](../../images/add_cluster/add-cluster-select-provider.png)
+![Add Cluster provider selection screen showing Vendor Managed and Self Managed sections with Public option](../../../images/add_cluster/add-cluster-select-provider.png)
 
 ### Provide Kubeconfig
 
 3. Provide the kubeconfig for your cluster.
 
-![Provide Kubeconfig screen showing YAML editor for public self-managed cluster](../../images/add_cluster/public-cluster-kubeconfig.png)
+![Provide Kubeconfig screen showing YAML editor for public self-managed cluster](../../../images/add_cluster/public-cluster-kubeconfig.png)
 
 ### Customize Features
 

--- a/docs/platform/guides/cluster-management/cluster-features.md
+++ b/docs/platform/guides/cluster-management/cluster-features.md
@@ -14,7 +14,7 @@ section_menu_id: guides
 
 **Feature Sets** are groups of AppsCode product capabilities that you can install or remove on any connected cluster. This page covers all 19 available Feature Sets and shows the enable flow for two common ones: **Backup & Recovery** and **Databases**.
 
-> For a per-feature breakdown of every Feature Set — what each feature does, why you'd enable it, and its prerequisites — see the [Feature Set Reference](feature-reference.md).
+> For a per-feature breakdown of every Feature Set — what each feature does, why you'd enable it, and its prerequisites — see the [Feature Set Reference](../feature-reference.md).
 
 ---
 

--- a/docs/platform/guides/cluster-management/cluster-helm-charts.md
+++ b/docs/platform/guides/cluster-management/cluster-helm-charts.md
@@ -30,7 +30,7 @@ Use this page to get a quick overview of all deployed charts, check release stat
 
 Lists every release with its **Name**, **Namespace**, **Status** (e.g. deployed, failed), **Version**, and **Age**. Use the **Select All** and **All Namespaces** dropdowns to filter the list.
 
-![Helm Releases page showing all deployed Helm releases with name, namespace, status, version, and age columns](images/cluster-helm-charts/helm-releases-deployed.png)
+![Helm Releases page showing all deployed Helm releases with name, namespace, status, version, and age columns](../images/cluster-helm-charts/helm-releases-deployed.png)
 
 ---
 
@@ -42,7 +42,7 @@ Use this page to check FluxCD-managed release health, spot failed reconciliation
 
 Lists every HelmRelease with its **Namespace**, **Age**, **Ready** status, and a **Status** message showing the last Helm operation result. Click **+ Create HelmRelease** to define a new one.
 
-![HelmRelease list page showing FluxCD-managed releases with namespace, age, ready, and status columns](images/cluster-helm-charts/helm-releases-list.png)
+![HelmRelease list page showing FluxCD-managed releases with namespace, age, ready, and status columns](../images/cluster-helm-charts/helm-releases-list.png)
 
 ---
 
@@ -54,7 +54,7 @@ Use this page to verify chart versions in use, check that chart sources are reso
 
 Lists every HelmChart with its **Namespace**, **Annotations**, **Age**, **Chart** name, **Version**, **Source Kind**, **Source Name**, **Ready** state, and **Status**. Click **+ Create HelmChart** to add a new chart source.
 
-![HelmChart list page showing chart name, version, source kind, source name, ready, and status columns](images/cluster-helm-charts/helm-charts-list.png)
+![HelmChart list page showing chart name, version, source kind, source name, ready, and status columns](../images/cluster-helm-charts/helm-charts-list.png)
 
 ---
 

--- a/docs/platform/guides/cluster-management/cluster-overview.md
+++ b/docs/platform/guides/cluster-management/cluster-overview.md
@@ -105,7 +105,7 @@ Hover over any **Not Installed** card to see a tooltip like *"No feature enabled
 
 ![Feature Sets grid with status badges — Ready (green) and Not Installed (red)](../images/cluster-overview/cluster-overview-4.png)
 
-Click any Feature Set card to open the **Feature Set Management** page where you can enable or configure its components. See [Feature Management](cluster-features.md) for a full walkthrough.
+Click any Feature Set card to open the **Feature Set Management** page where you can enable or configure its components. See [Feature Management](../cluster-features.md) for a full walkthrough.
 
 ---
 

--- a/docs/platform/guides/cluster-management/cluster-workload.md
+++ b/docs/platform/guides/cluster-management/cluster-workload.md
@@ -30,7 +30,7 @@ A Deployment keeps a set number of identical app copies running and handles roll
 
 Lists every Deployment with its Namespace, Pods (ready count), Images, and Age. Click a row to view or edit it; use **+ Create** to deploy a new one.
 
-![Deployments list page showing the table of deployments with namespace filter and Create button](images/cluster-workload/deployments-list.png)
+![Deployments list page showing the table of deployments with namespace filter and Create button](../images/cluster-workload/deployments-list.png)
 
 ---
 
@@ -40,7 +40,7 @@ A Replica Set's only job is to keep a fixed number of Pod copies alive. You rare
 
 Lists every Replica Set with its Namespace, Pods, Images, and Age.
 
-![Replica Sets list page showing namespace, pods, images, and age columns](images/cluster-workload/replica-sets-list.png)
+![Replica Sets list page showing namespace, pods, images, and age columns](../images/cluster-workload/replica-sets-list.png)
 
 ---
 
@@ -50,7 +50,7 @@ The older, legacy way to keep a fixed number of Pod copies running — same idea
 
 Lists every Replication Controller with its Namespace, Pods, Images, and Age. Click **+ Create ReplicationController** to add one.
 
-![Replication Controllers list page with no data available and a Create ReplicationController button](images/cluster-workload/replication-controllers-list.png)
+![Replication Controllers list page with no data available and a Create ReplicationController button](../images/cluster-workload/replication-controllers-list.png)
 
 ---
 
@@ -60,7 +60,7 @@ For apps where each Pod needs a stable identity and its own storage — database
 
 Lists every Stateful Set with its Namespace, Pods, Images, and Age.
 
-![Stateful Sets list page showing namespace, pods, images, and age columns](images/cluster-workload/stateful-sets-list.png)
+![Stateful Sets list page showing namespace, pods, images, and age columns](../images/cluster-workload/stateful-sets-list.png)
 
 ---
 
@@ -70,7 +70,7 @@ Runs one copy of a Pod on every node automatically — typically used for cluste
 
 Lists every Daemon Set with its Namespace, Pods, Dsired, Current-Scheduled, Up-to-date, Node Selector, Images, and Age — the Desired/Current/Up-to-date columns show rollout progress at a glance.
 
-![Daemon Sets list page showing desired, current-scheduled, and up-to-date columns](images/cluster-workload/daemon-sets-list.png)
+![Daemon Sets list page showing desired, current-scheduled, and up-to-date columns](../images/cluster-workload/daemon-sets-list.png)
 
 ---
 
@@ -80,7 +80,7 @@ A Job runs a task once until it completes — a backup, a migration script, a on
 
 Lists every Job with its Namespace, Annotations, Completions, Duration, Images, and Age.
 
-![Jobs list page showing completions, duration, images, and age columns](images/cluster-workload/jobs-list.png)
+![Jobs list page showing completions, duration, images, and age columns](../images/cluster-workload/jobs-list.png)
 
 ---
 
@@ -90,7 +90,7 @@ A Cron Job runs a Job on a repeating schedule — like a nightly backup or a rec
 
 Lists every Cron Job with its Namespace, Annotations, Schedule, Suspend, Active, Last Schedule, Images, and Age — the Schedule column shows the cron expression.
 
-![Cron Jobs list page showing schedule, suspend, active, and last schedule columns](images/cluster-workload/cron-jobs-list.png)
+![Cron Jobs list page showing schedule, suspend, active, and last schedule columns](../images/cluster-workload/cron-jobs-list.png)
 
 ---
 
@@ -100,7 +100,7 @@ A Pod is the actual running container(s) — the smallest unit in Kubernetes. Ev
 
 Lists every Pod with its Namespace, Ready, Status, Restarts, IP, Images, and Age — the only Workloads item with these extra live-state columns, useful for spotting crashing or restarting containers.
 
-![Pods list page showing Ready, Status, Restarts, and IP columns](images/cluster-workload/pods-list.png)
+![Pods list page showing Ready, Status, Restarts, and IP columns](../images/cluster-workload/pods-list.png)
 
 ---
 

--- a/docs/platform/guides/cluster-management/feature-reference.md
+++ b/docs/platform/guides/cluster-management/feature-reference.md
@@ -30,9 +30,9 @@ Core platform capabilities. Must be installed before any other Feature Set.
 | **OpenShift Adapter** | Adapts the platform to OpenShift. Enable only on OpenShift clusters. | — |
 | **Opscenter Features** *(Required)* | Internal configurator that renders feature definitions. Platform-managed. | — |
 
-Note: If you are an ArgoCD user, AppsCode provides a way to convert the flux HelmRelease to an Argo Application via a custom operator called FargoCD. This is configurable in the [selfhost](../../selfhost-setup/install/_index.md) page.
+Note: If you are an ArgoCD user, AppsCode provides a way to convert the flux HelmRelease to an Argo Application via a custom operator called FargoCD. This is configurable in the [selfhost](../../../selfhost-setup/install/_index.md) page.
 
-![Configure Opscenter Core feature set showing Opscenter Features, Kube UI Server, License Proxyserver, FluxCD, and OpenShift Adapter](images/feature-reference-images/featureset-opscenter-core.png)
+![Configure Opscenter Core feature set showing Opscenter Features, Kube UI Server, License Proxyserver, FluxCD, and OpenShift Adapter](../images/feature-reference-images/featureset-opscenter-core.png)
 
 ---
 
@@ -47,7 +47,7 @@ Scheduled backup and recovery for Kubernetes applications and databases.
 | **Stash** | Legacy backup operator (Stash 1.0). Enable only to keep existing Stash 1.0 setups working. | License Proxyserver |
 | **Stash Opscenter** | UI and Grafana monitoring for Stash. | Stash, Panopticon, Grafana Operator |
 
-![Configure Backup & Recovery feature set showing Stash Opscenter, Stash 2.0, Stash, and Stash Presets](images/feature-reference-images/featureset-backup-recovery.png)
+![Configure Backup & Recovery feature set showing Stash Opscenter, Stash 2.0, Stash, and Stash Presets](../images/feature-reference-images/featureset-backup-recovery.png)
 
 ---
 
@@ -62,7 +62,7 @@ Production-grade database management powered by KubeDB.
 | **KubeDB UI Presets** *(Recommended)* | Default presets for the database creation forms. | — |
 | **Prepare Cluster** | Pre-pulls images and prepares nodes for KubeDB. | — |
 
-![Configure Databases feature set showing KubeDB Opscenter, Prepare Cluster, KubeDB UI Presets, and KubeDB with supported database types](images/feature-reference-images/featureset-databases.png)
+![Configure Databases feature set showing KubeDB Opscenter, Prepare Cluster, KubeDB UI Presets, and KubeDB with supported database types](../images/feature-reference-images/featureset-databases.png)
 
 ---
 
@@ -85,7 +85,7 @@ Cluster monitoring, metrics, and dashboards.
 | **Tenant Operator** *(Recommended)* | Isolates monitoring resources and access per tenant. | Prometheus Label Proxy, Thanos Operator |
 | **Inbox Agent / Server / UI** *(ALPHA)* | Cluster event inbox components. | — |
 
-![Configure Observability feature set showing Panopticon, Prometheus Metrics Adapter, Monitoring Operator, Kube Prometheus Stack, Grafana Operator, and Inbox components](images/feature-reference-images/featureset-observability.png)
+![Configure Observability feature set showing Panopticon, Prometheus Metrics Adapter, Monitoring Operator, Kube Prometheus Stack, Grafana Operator, and Inbox components](../images/feature-reference-images/featureset-observability.png)
 
 ---
 
@@ -100,7 +100,7 @@ Measure and allocate infrastructure and container costs.
 | **Opencost** *(ALPHA)* | Measure and allocate infrastructure and container costs. | Kube Prometheus Stack, Monitoring Operator |
 | **OpenCost Grafana Dashboards** | Cost visualization dashboards. | Opencost, Grafana Operator |
 
-![Configure Cost Management feature set showing Keda HTTP Addon, OpenCost Grafana Dashboards, Opencost, and Keda](images/feature-reference-images/featureset-cost-management.png)
+![Configure Cost Management feature set showing Keda HTTP Addon, OpenCost Grafana Dashboards, Opencost, and Keda](../images/feature-reference-images/featureset-cost-management.png)
 
 ---
 
@@ -116,7 +116,7 @@ TLS certificates, runtime security, and image scanning.
 | **Falco** | Container-native runtime threat detection. | — |
 | **Falco UI Server** | UI for Falco runtime alerts. | Falco, Grafana Operator |
 
-![Configure Security feature set showing Falco UI Server, Falco, CA Cert CSI Driver, Cert Manager, and Scanner](images/feature-reference-images/featureset-security.png)
+![Configure Security feature set showing Falco UI Server, Falco, CA Cert CSI Driver, Cert Manager, and Scanner](../images/feature-reference-images/featureset-security.png)
 
 ---
 
@@ -141,7 +141,7 @@ Secure secret storage, syncing, and distribution.
 | **Virtual Secrets** *(ALPHA)* | Virtual Secrets server for not to actually keep the secrets in k8s level. | — |
 | **Virtual Secrets provider** *(ALPHA)* | Virtual Secrets backend for the CSI driver. | Virtual Secrets, Secrets Store CSI Driver |
 
-![Configure Secret Management feature set showing External Secrets, Kubevault, Config Syncer, Reloader, Sealed Secrets, CSI driver providers, and Virtual Secrets](images/feature-reference-images/featureset-secret-management.png)
+![Configure Secret Management feature set showing External Secrets, Kubevault, Config Syncer, Reloader, Sealed Secrets, CSI driver providers, and Virtual Secrets](../images/feature-reference-images/featureset-secret-management.png)
 
 ---
 
@@ -158,7 +158,7 @@ Platform-level policy enforcement.
 | **Kyverno** | Kubernetes-native policy management. | — |
 | **Kyverno Policies** | Pod Security Standards implemented as Kyverno policies. | Kyverno |
 
-![Configure Policy Management feature set showing Kyverno Policies, Gatekeeper, Kyverno, GateKeeper Policy Grafana Dashboards, Gatekeeper Templates, and Gatekeeper Constraints](images/feature-reference-images/featureset-policy-management.png)
+![Configure Policy Management feature set showing Kyverno Policies, Gatekeeper, Kyverno, GateKeeper Policy Grafana Dashboards, Gatekeeper Templates, and Gatekeeper Constraints](../images/feature-reference-images/featureset-policy-management.png)
 
 ---
 
@@ -173,7 +173,7 @@ Additional storage drivers and integrations.
 | **CSI Volume Snapshotter** | Snapshot controller and validation webhook for CSI volumes. | — |
 | **TopoLVM** | Local LVM-backed CSI storage. | — |
 
-![Configure Storage Addons feature set showing Longhorn, NFS CSI driver, CSI Volume Snapshotter, and TopoLVM](images/feature-reference-images/featureset-storage-addons.png)
+![Configure Storage Addons feature set showing Longhorn, NFS CSI driver, CSI Volume Snapshotter, and TopoLVM](../images/feature-reference-images/featureset-storage-addons.png)
 
 ---
 
@@ -188,7 +188,7 @@ Networking plugins and extensions.
 | **Voyager Ingress** | HAProxy-based ingress controller. | — |
 | **Voyager Gateway** | Envoy-based gateway distro by AppsCode. | — |
 
-![Configure Networking Addons feature set showing Voyager Gateway, Kubernetes Gateway API, External DNS Operator, and Voyager Ingress](images/feature-reference-images/featureset-networking-addons.png)
+![Configure Networking Addons feature set showing Voyager Gateway, Kubernetes Gateway API, External DNS Operator, and Voyager Ingress](../images/feature-reference-images/featureset-networking-addons.png)
 
 ---
 
@@ -202,7 +202,7 @@ DevOps tooling and management utilities.
 | **Sidekick** *(Recommended)* | Run a one-off container as a pod (sidecar-as-a-pod). | — |
 | **Operator Shard Manager** *(Recommended)* | Scale operators by sharding responsibility across instances. | — |
 
-![Configure Opscenter Tools feature set showing Operator Shard Manager, Sidekick, and Supervisor](images/feature-reference-images/featureset-opscenter-tools.png)
+![Configure Opscenter Tools feature set showing Operator Shard Manager, Sidekick, and Supervisor](../images/feature-reference-images/featureset-opscenter-tools.png)
 
 ---
 
@@ -216,7 +216,7 @@ Cluster provisioning and management tools (Cluster API core).
 | **CAPI Ops Manager** | Day-2 operations for Cluster API clusters. | — |
 | **Cluster Presets** | Preset configurations for cluster provisioning. Work with cloud NodePools | — |
 
-![Configure Cluster Management feature set showing CAPI Catalog, CAPI Ops Manager, and Cluster Presets](images/feature-reference-images/featureset-cluster-management.png)
+![Configure Cluster Management feature set showing CAPI Catalog, CAPI Ops Manager, and Cluster Presets](../images/feature-reference-images/featureset-cluster-management.png)
 
 ---
 
@@ -232,7 +232,7 @@ Lifecycle management for clusters running on AWS.
 | **AWS VPC Peering Operator** *(Recommended)* | Manage AWS VPC peering connections. | — |
 | **Cluster Autoscaler** *(Recommended)* | Node autoscaling for Cluster API clusters. | — |
 
-![Configure Cluster API AWS (CAPA) feature set showing AWS VPC Peering Operator, AWS Credential Manager, Cluster Autoscaler, AWS Load Balancer Controller, and AWS EBS CSI Driver](images/feature-reference-images/featureset-capi-aws.png)
+![Configure Cluster API AWS (CAPA) feature set showing AWS VPC Peering Operator, AWS Credential Manager, Cluster Autoscaler, AWS Load Balancer Controller, and AWS EBS CSI Driver](../images/feature-reference-images/featureset-capi-aws.png)
 
 ---
 
@@ -244,7 +244,7 @@ Lifecycle management for clusters running on GCP.
 |---|---|---|
 | **GCP Credential Manager** *(Recommended)* | Manage GCP credentials used by CAPG. | — |
 
-![Configure Cluster API GCP (CAPG) feature set showing GCP Credential Manager](images/feature-reference-images/featureset-capi-gcp.png)
+![Configure Cluster API GCP (CAPG) feature set showing GCP Credential Manager](../images/feature-reference-images/featureset-capi-gcp.png)
 
 ---
 
@@ -256,7 +256,7 @@ Lifecycle management for clusters running on Azure.
 |---|---|---|
 | **Azure Credential Manager** *(Recommended)* | Manage Azure credentials used by CAPZ. | — |
 
-![Configure Cluster API Azure (CAPZ) feature set showing Azure Credential Manager](images/feature-reference-images/featureset-capi-azure.png)
+![Configure Cluster API Azure (CAPZ) feature set showing Azure Credential Manager](../images/feature-reference-images/featureset-capi-azure.png)
 
 ---
 
@@ -271,7 +271,7 @@ Control-plane framework for infrastructure as code.
 | **KubeDB Azure Provider** | Provision KubeDB databases on Azure through Crossplane. | Crossplane |
 | **KubeDB GCP Provider** | Provision KubeDB databases on GCP through Crossplane. | Crossplane |
 
-![Configure Crossplane feature set showing KubeDB GCP Provider, KubeDB Azure Provider, KubeDB AWS Provider, and Crossplane](images/feature-reference-images/featureset-crossplane.png)
+![Configure Crossplane feature set showing KubeDB GCP Provider, KubeDB Azure Provider, KubeDB AWS Provider, and Crossplane](../images/feature-reference-images/featureset-crossplane.png)
 
 ---
 
@@ -291,7 +291,7 @@ Central hub for managing a fleet of clusters.
 | **License Proxyserver Manager** *(Recommended)* | Distribute AppsCode licenses to spoke clusters. | Multicluster Hub, Cluster Profile Manager |
 | **Hub Cluster Robot** *(Recommended)* | Automation account for hub-driven operations. | Multicluster Hub, Cluster Auth Manager |
 
-![Configure Multicluster Hub feature set showing Cluster Gateway Manager, Cluster Profile Manager, Managed ServiceAccount Manager, Cluster Auth Manager, Hub Cluster Robot, FluxCD Manager, License Proxyserver Manager, Cluster Proxy Manager, and Multicluster Hub](images/feature-reference-images/featureset-multicluster-hub.png)
+![Configure Multicluster Hub feature set showing Cluster Gateway Manager, Cluster Profile Manager, Managed ServiceAccount Manager, Cluster Auth Manager, Hub Cluster Robot, FluxCD Manager, License Proxyserver Manager, Cluster Proxy Manager, and Multicluster Hub](../images/feature-reference-images/featureset-multicluster-hub.png)
 
 ---
 
@@ -303,7 +303,7 @@ Connect this cluster as a spoke to an existing hub.
 |---|---|---|
 | **Multicluster Spoke** *(Recommended)* | Register this cluster as a spoke of a Multicluster Hub. | — |
 
-![Configure Multicluster Spoke feature set showing Multicluster Spoke component with Hub Information and Spoke Information fields](images/feature-reference-images/featureset-multicluster-spoke.png)
+![Configure Multicluster Spoke feature set showing Multicluster Spoke component with Hub Information and Spoke Information fields](../images/feature-reference-images/featureset-multicluster-spoke.png)
 
 ---
 
@@ -318,4 +318,4 @@ Components for Kubernetes-native service patterns.
 | **Service Connector Backend** | Backend for the service connector. | — |
 | **Service Provider** | Service provider component. | — |
 
-![Configure Kubernetes Native Service feature set showing Service Catalog, Service Connector Backend, Service Gateway Presets, and Service Provider](images/feature-reference-images/featureset-kubernetes-native-service.png)
+![Configure Kubernetes Native Service feature set showing Service Catalog, Service Connector Backend, Service Gateway Presets, and Service Provider](../images/feature-reference-images/featureset-kubernetes-native-service.png)

--- a/docs/platform/guides/cluster-management/remove-cluster.md
+++ b/docs/platform/guides/cluster-management/remove-cluster.md
@@ -14,7 +14,7 @@ section_menu_id: guides
 
 From the cluster list, click the **⋮** (three-dot) menu on any cluster card to access two actions: **Remove** and **Delete**.
 
-![Cluster options menu showing KubeConfig, Remove, and Delete actions](images/remove-cluster/cluster-options-menu.png)
+![Cluster options menu showing KubeConfig, Remove, and Delete actions](../images/remove-cluster/cluster-options-menu.png)
 
 ---
 
@@ -29,7 +29,7 @@ From the cluster list, click the **⋮** (three-dot) menu on any cluster card to
    - **Remove All Features** — uninstalls all installed feature-sets from the cluster.
 4. Click **Yes, Remove**.
 
-![Remove Cluster modal with optional checkboxes for Remove FluxCD and Remove All Features](images/remove-cluster/remove-cluster-modal.png)
+![Remove Cluster modal with optional checkboxes for Remove FluxCD and Remove All Features](../images/remove-cluster/remove-cluster-modal.png)
 
 ---
 
@@ -41,7 +41,7 @@ From the cluster list, click the **⋮** (three-dot) menu on any cluster card to
 2. Click **Delete**.
 3. Confirm in the modal by clicking **Yes, Delete**.
 
-![Delete Cluster modal asking for confirmation with Yes, Delete button](images/remove-cluster/delete-cluster-modal.png)
+![Delete Cluster modal asking for confirmation with Yes, Delete button](../images/remove-cluster/delete-cluster-modal.png)
 
 > **Warning:** Delete tears down the actual infrastructure. Use **Remove** if you only want to unregister the cluster from the UI.
 

--- a/docs/platform/guides/database-management/create-database/_index.md
+++ b/docs/platform/guides/database-management/create-database/_index.md
@@ -17,7 +17,7 @@ namespace, configure topology and resources, and enable optional features like
 monitoring, TLS, and backups.
 
 The overall flow is the same for every engine and is documented once in
-[**Common Steps**](common-steps.md). Where it differs is the **Database Mode** (topology)
+[**Common Steps**](../common-steps.md). Where it differs is the **Database Mode** (topology)
 and a handful of engine-specific settings — pick your engine below for a guide tailored to
 it, then follow the common steps for everything else.
 
@@ -26,49 +26,49 @@ it, then follow the common steps for everything else.
 ## Supported Engines
 
 ### Relational
-- [PostgreSQL](postgres.md)
-- [MySQL](mysql.md)
-- [MariaDB](mariadb.md)
-- [Percona XtraDB](perconaxtradb.md)
-- [Microsoft SQL Server](mssqlserver.md)
-- [Oracle](oracle.md)
-- [SingleStore](singlestore.md)
-- [IBM Db2](db2.md)
-- [SAP HANA](hanadb.md)
+- [PostgreSQL](../postgres.md)
+- [MySQL](../mysql.md)
+- [MariaDB](../mariadb.md)
+- [Percona XtraDB](../perconaxtradb.md)
+- [Microsoft SQL Server](../mssqlserver.md)
+- [Oracle](../oracle.md)
+- [SingleStore](../singlestore.md)
+- [IBM Db2](../db2.md)
+- [SAP HANA](../hanadb.md)
 
 ### Document & Search
-- [MongoDB](mongodb.md)
-- [Elasticsearch](elasticsearch.md)
-- [Solr](solr.md)
-- [DocumentDB](documentdb.md)
+- [MongoDB](../mongodb.md)
+- [Elasticsearch](../elasticsearch.md)
+- [Solr](../solr.md)
+- [DocumentDB](../documentdb.md)
 
 ### Key-Value & Cache
-- [Redis](redis.md)
-- [Memcached](memcached.md)
-- [Ignite](ignite.md)
-- [Hazelcast](hazelcast.md)
+- [Redis](../redis.md)
+- [Memcached](../memcached.md)
+- [Ignite](../ignite.md)
+- [Hazelcast](../hazelcast.md)
 
 ### Vector
-- [Qdrant](qdrant.md)
-- [Milvus](milvus.md)
-- [Weaviate](weaviate.md)
+- [Qdrant](../qdrant.md)
+- [Milvus](../milvus.md)
+- [Weaviate](../weaviate.md)
 
 ### Wide-column & Time-series
-- [Cassandra](cassandra.md)
-- [ClickHouse](clickhouse.md)
-- [Druid](druid.md)
+- [Cassandra](../cassandra.md)
+- [ClickHouse](../clickhouse.md)
+- [Druid](../druid.md)
 
 ### Streaming & Messaging
-- [Kafka](kafka.md)
-- [RabbitMQ](rabbitmq.md)
+- [Kafka](../kafka.md)
+- [RabbitMQ](../rabbitmq.md)
 
 ### Graph
-- [Neo4j](neo4j.md)
+- [Neo4j](../neo4j.md)
 
 ### Coordination
-- [ZooKeeper](zookeeper.md)
+- [ZooKeeper](../zookeeper.md)
 
 ### Connection Poolers & Proxies
-- [PgBouncer](pgbouncer.md)
-- [Pgpool](pgpool.md)
-- [ProxySQL](proxysql.md)
+- [PgBouncer](../pgbouncer.md)
+- [Pgpool](../pgpool.md)
+- [ProxySQL](../proxysql.md)

--- a/docs/platform/guides/database-management/create-database/cassandra.md
+++ b/docs/platform/guides/database-management/create-database/cassandra.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Cassandra** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**:
 - **Standalone** — A single-node Cassandra instance for development or testing.
 - **Topology** — A multi-node Cassandra cluster, optionally organized into named **Racks** for rack-aware replication.
 
-![Topology mode selected showing Racks configuration](../images/db-create/cassandra/topology-mode.png)
+![Topology mode selected showing Racks configuration](../../images/db-create/cassandra/topology-mode.png)
 
 | Field | Description |
 |---|---|
@@ -33,8 +33,8 @@ Select the topology under **Database Mode**:
 
 ## Create a Cassandra Database
 
-1. Open the wizard and select **Cassandra** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Cassandra** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/clickhouse.md
+++ b/docs/platform/guides/database-management/create-database/clickhouse.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **ClickHouse** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**:
 - **Standalone** — A single-node ClickHouse instance.
 - **Topology** — A distributed ClickHouse cluster with sharding/replication, coordinated by ClickHouse Keeper.
 
-![Topology mode selected showing Cluster and ClickHouse Keeper configuration](../images/db-create/clickhouse/topology-mode.png)
+![Topology mode selected showing Cluster and ClickHouse Keeper configuration](../../images/db-create/clickhouse/topology-mode.png)
 
 **Cluster**
 
@@ -37,8 +37,8 @@ Select the topology under **Database Mode**:
 
 ## Create a ClickHouse Database
 
-1. Open the wizard and select **ClickHouse** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **ClickHouse** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/common-steps.md
+++ b/docs/platform/guides/database-management/create-database/common-steps.md
@@ -17,7 +17,7 @@ These steps are the same for every database engine. Each engine's own page cover
 the engine-specific **Database Mode**; everything else — opening the wizard, naming,
 versions, resources, and optional features — is described here.
 
-> Start on your engine's page (e.g. [PostgreSQL](postgres.md), [Redis](redis.md)) for the
+> Start on your engine's page (e.g. [PostgreSQL](../postgres.md), [Redis](../redis.md)) for the
 > Database Mode, and refer back to this page for the surrounding steps.
 
 ---
@@ -28,7 +28,7 @@ Navigate to the **Datastore** section in the left sidebar. The **Datastore Overv
 
 To create a new database, click the green **+ Create New Instance** button in the top-right corner of the page.
 
-![Datastore Overview page showing existing database instances and the Create New Instance button](../images/db-create/shared/overview-create.png)
+![Datastore Overview page showing existing database instances and the Create New Instance button](../../images/db-create/shared/overview-create.png)
 
 ---
 
@@ -36,7 +36,7 @@ To create a new database, click the green **+ Create New Instance** button in th
 
 You will be presented with a grid of all supported database engines. Click the engine you want to provision.
 
-![Database type selection grid showing all supported engines](../images/db-create/shared/db-type-select.png)
+![Database type selection grid showing all supported engines](../../images/db-create/shared/db-type-select.png)
 
 > **Tip:** Supported engines include relational, document, key-value, search, vector, and time-series databases.
 
@@ -46,7 +46,7 @@ You will be presented with a grid of all supported database engines. Click the e
 
 After selecting the database type, choose a namespace and provide a name for the new instance.
 
-![Choose Namespace and Name step showing Select Namespace dropdown and Name field](../images/db-create/shared/name-namespace-select.png)
+![Choose Namespace and Name step showing Select Namespace dropdown and Name field](../../images/db-create/shared/name-namespace-select.png)
 
 1. **Select Namespace:** The Kubernetes namespace where the database will be deployed. If the namespace has resource quotas, available CPU and memory are shown.
 1. **Name:** A unique name that starts with a lowercase letter and contains only letters, numbers, or dashes.
@@ -67,13 +67,13 @@ Select the engine version from the **Database Version** dropdown. The version de
 
 ### 4.2 - Database Mode
 
-The available topologies depend on the engine. See your engine's page for its **Database Mode** options and fields — for example [MongoDB](mongodb.md) (Standalone / Replicaset / Sharded) or [PostgreSQL](postgres.md) (Standalone / Cluster / RemoteReplica).
+The available topologies depend on the engine. See your engine's page for its **Database Mode** options and fields — for example [MongoDB](../mongodb.md) (Standalone / Replicaset / Sharded) or [PostgreSQL](../postgres.md) (Standalone / Cluster / RemoteReplica).
 
 ### 4.3 - Machine Profile
 
 The **Machine Profile** dropdown selects a preset CPU and memory configuration for your database nodes. Choose `custom` to enter CPU and memory values manually.
 
-![Machine Profile dropdown alongside the Storage Class and Advanced Configuration panels](../images/db-create/shared/machine-profile.png)
+![Machine Profile dropdown alongside the Storage Class and Advanced Configuration panels](../../images/db-create/shared/machine-profile.png)
 
 > **Tip:** Preset profiles are named by size (e.g., `db.t4large`). Use `custom` when your workload requires resources that do not match any preset.
 
@@ -81,7 +81,7 @@ The **Machine Profile** dropdown selects a preset CPU and memory configuration f
 
 Select the Kubernetes **Storage Class** that backs the persistent volumes and enter the required **Storage size**.
 
-![Storage Class dropdown and Storage size field](../images/db-create/shared/storage-class.png)
+![Storage Class dropdown and Storage size field](../../images/db-create/shared/storage-class.png)
 
 | Field | Description |
 |---|---|
@@ -98,7 +98,7 @@ Expand the **Advanced Configuration** panel (*Configure Credentials, Deployment 
 
 Add custom Kubernetes labels and annotations to the database resources.
 
-![Labels and Annotations sections each with Key-Value input rows and Add new buttons](../images/db-create/shared/advance-lavel-annotation.png)
+![Labels and Annotations sections each with Key-Value input rows and Add new buttons](../../images/db-create/shared/advance-lavel-annotation.png)
 
 - Use **+ Add new** under **Labels** / **Annotations** to attach key-value pairs.
 - Use the delete icon on any row to remove it.
@@ -107,7 +107,7 @@ Add custom Kubernetes labels and annotations to the database resources.
 
 The **Deletion Policy** dropdown controls what happens to the resources when the database object is deleted.
 
-![Deletion Policy dropdown showing Delete, Halt, WipeOut, and DoNotTerminate options](../images/db-create/shared/deletion-policy.png)
+![Deletion Policy dropdown showing Delete, Halt, WipeOut, and DoNotTerminate options](../../images/db-create/shared/deletion-policy.png)
 
 | Option | Behaviour |
 |---|---|
@@ -122,7 +122,7 @@ The **Deletion Policy** dropdown controls what happens to the resources when the
 
 Configure how the database credentials are managed.
 
-![Authentication Credentials section showing credential toggles, Secret dropdown, Password field, and Configuration textarea](../images/db-create/shared/auth-creds.png)
+![Authentication Credentials section showing credential toggles, Secret dropdown, Password field, and Configuration textarea](../../images/db-create/shared/auth-creds.png)
 
 | Field | Description |
 |---|---|
@@ -135,7 +135,7 @@ Configure how the database credentials are managed.
 
 For engines that support continuous archiving (e.g. **PostgreSQL**, **MySQL**), enable **Point in-time Recovery** to restore the new database from a previous backup to an exact timestamp.
 
-![Point in-time Recovery form showing Namespace, Name, and Recovery Timestamp fields](../images/db-create/shared/point-in-time-recovery.png)
+![Point in-time Recovery form showing Namespace, Name, and Recovery Timestamp fields](../../images/db-create/shared/point-in-time-recovery.png)
 
 1. **Namespace:** The namespace where the source backup resides. Required.
 1. **Name:** The name of the source database to recover from. Required.
@@ -149,7 +149,7 @@ For engines that support continuous archiving (e.g. **PostgreSQL**, **MySQL**), 
 
 Expand the **Additional Options** panel (*Enable Backup, Monitoring, TLS etc.*) to enable integrated platform features.
 
-![Additional Options panel showing Monitoring, Backup, TLS, and Gateway toggles](../images/db-create/shared/Additional-option.png)
+![Additional Options panel showing Monitoring, Backup, TLS, and Gateway toggles](../../images/db-create/shared/Additional-option.png)
 
 | Option | Description |
 |---|---|

--- a/docs/platform/guides/database-management/create-database/db2.md
+++ b/docs/platform/guides/database-management/create-database/db2.md
@@ -15,13 +15,11 @@ section_menu_id: guides
 
 This page covers the configuration specific to **IBM Db2** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
 IBM Db2 is deployed as a single logical instance. Set the **Number of Replicas** to control how many nodes back the instance for availability.
-
-![Replicas configuration for IBM Db2](../images/db-create/db2/replicas.png)
 
 | Field | Description |
 |---|---|
@@ -29,8 +27,8 @@ IBM Db2 is deployed as a single logical instance. Set the **Number of Replicas**
 
 ## Create a IBM Db2 Database
 
-1. Open the wizard and select **IBM Db2** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **IBM Db2** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/documentdb.md
+++ b/docs/platform/guides/database-management/create-database/documentdb.md
@@ -15,13 +15,13 @@ section_menu_id: guides
 
 This page covers the configuration specific to **DocumentDB** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
 DocumentDB is deployed as a single logical instance. Set the **Number of Replicas** to control how many nodes back the instance for availability.
 
-![Replicas configuration for DocumentDB](../images/db-create/documentdb/replicas.png)
+![Replicas configuration for DocumentDB](../../images/db-create/documentdb/replicas.png)
 
 | Field | Description |
 |---|---|
@@ -29,8 +29,8 @@ DocumentDB is deployed as a single logical instance. Set the **Number of Replica
 
 ## Create a DocumentDB Database
 
-1. Open the wizard and select **DocumentDB** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **DocumentDB** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/druid.md
+++ b/docs/platform/guides/database-management/create-database/druid.md
@@ -15,15 +15,15 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Druid** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
 Druid is always deployed as a **Topology** of role-separated process tiers. Configure each tier's node count and resources independently.
 
-![Druid topology showing Overlords/MiddleManagers and Historicals panels](../images/db-create/druid/topology-mode-1.png)
+![Druid topology showing Overlords/MiddleManagers and Historicals panels](../../images/db-create/druid/topology-mode-1.png)
 
-![Druid topology showing Coordinators and Brokers panels](../images/db-create/druid/topology-mode-2.png)
+![Druid topology showing Coordinators and Brokers panels](../../images/db-create/druid/topology-mode-2.png)
 
 | Node | Description |
 |---|---|
@@ -37,8 +37,6 @@ Each tier has its own **Number of Replicas**, **Storage size**, **Machine**, **C
 ## Druid Dependencies
 
 Druid relies on external dependencies for metadata, deep storage, and coordination. Each can be provisioned by the platform or pointed at an existing, externally-managed instance.
-
-![Druid deep storage, metadata storage, and ZooKeeper configuration](../images/db-create/druid/dependencies.png)
 
 **Deep Storage** — Durable storage for Druid segments.
 
@@ -64,8 +62,8 @@ Druid relies on external dependencies for metadata, deep storage, and coordinati
 
 ## Create a Druid Database
 
-1. Open the wizard and select **Druid** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Druid** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/elasticsearch.md
+++ b/docs/platform/guides/database-management/create-database/elasticsearch.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Elasticsearch** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**:
 - **Combined** — A single pool of nodes that perform all roles (master, data, ingest). Simpler; best for smaller deployments.
 - **Topology** — Role-separated nodes split into **Master**, **Data**, and **Ingest** tiers, each scaled and resourced independently.
 
-![Topology mode selected showing Master, Data, and Ingest node panels](../images/db-create/elasticsearch/topology-mode.png)
+![Topology mode selected showing Master, Data, and Ingest node panels](../../images/db-create/elasticsearch/topology-mode.png)
 
 | Node | Description |
 |---|---|
@@ -36,7 +36,7 @@ Each tier has its own **Number of Replicas**, **Storage size**, **Machine**, **C
 
 ## Elasticsearch Settings
 
-![Elasticsearch auth plugin selection](../images/db-create/elasticsearch/settings.png)
+![Elasticsearch auth plugin selection](../../images/db-create/elasticsearch/settings.png)
 
 | Field | Description |
 |---|---|
@@ -45,8 +45,8 @@ Each tier has its own **Number of Replicas**, **Storage size**, **Machine**, **C
 
 ## Create a Elasticsearch Database
 
-1. Open the wizard and select **Elasticsearch** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Elasticsearch** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/hanadb.md
+++ b/docs/platform/guides/database-management/create-database/hanadb.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **SAP HANA** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**:
 - **Standalone** — A single-node SAP HANA instance.
 - **SystemReplication** — A HANA System Replication setup with a primary and secondary site for high availability.
 
-![SystemReplication mode selected showing replication configuration](../images/db-create/hanadb/mode-select.png)
+![SystemReplication mode selected showing replication configuration](../../images/db-create/hanadb/mode-select.png)
 
 When **SystemReplication** is selected:
 
@@ -36,8 +36,8 @@ When **SystemReplication** is selected:
 
 ## Create a SAP HANA Database
 
-1. Open the wizard and select **SAP HANA** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **SAP HANA** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/hazelcast.md
+++ b/docs/platform/guides/database-management/create-database/hazelcast.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Hazelcast** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**:
 - **Combined** — A single pool of members forming one Hazelcast cluster. Best for most deployments.
 - **Topology** — Role-separated member tiers, each scaled and resourced independently.
 
-![Topology mode selected showing member node configuration](../images/db-create/hazelcast/topology-mode.png)
+![Topology mode selected showing member node configuration](../../images/db-create/hazelcast/topology-mode.png)
 
 | Field | Description |
 |---|---|
@@ -40,8 +40,8 @@ Hazelcast Enterprise features require a license.
 
 ## Create a Hazelcast Database
 
-1. Open the wizard and select **Hazelcast** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Hazelcast** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/ignite.md
+++ b/docs/platform/guides/database-management/create-database/ignite.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Ignite** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**. Two modes are available:
 - **Standalone** — A single-node instance. Best for development or low-traffic workloads.
 - **Replicaset** — A multi-node cluster for high availability. Set the **Number of Replicas** (e.g., `3`).
 
-![Replicaset mode selected showing the Number of Replicas field](../images/db-create/ignite/replicaset-mode.png)
+![Replicaset mode selected showing the Number of Replicas field](../../images/db-create/ignite/replicaset-mode.png)
 
 | Field | Description |
 |---|---|
@@ -32,8 +32,8 @@ Select the topology under **Database Mode**. Two modes are available:
 
 ## Create a Ignite Database
 
-1. Open the wizard and select **Ignite** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Ignite** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/kafka.md
+++ b/docs/platform/guides/database-management/create-database/kafka.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Kafka** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**:
 - **Combined** — Nodes act as both controller and broker. Simpler; best for smaller deployments.
 - **Topology** — Role-separated **Controller** and **Broker** node tiers (KRaft), each scaled and resourced independently.
 
-![Topology mode selected showing Controller and Broker node panels](../images/db-create/kafka/topology-mode.png)
+![Topology mode selected showing Controller and Broker node panels](../../images/db-create/kafka/topology-mode.png)
 
 | Node | Description |
 |---|---|
@@ -35,8 +35,8 @@ Each tier has its own **Number of Replicas**, **Storage size**, **Machine**, **C
 
 ## Create a Kafka Database
 
-1. Open the wizard and select **Kafka** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Kafka** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/mariadb.md
+++ b/docs/platform/guides/database-management/create-database/mariadb.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **MariaDB** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**. Two modes are available:
 - **Standalone** — A single-node instance. Best for development or low-traffic workloads.
 - **Replicaset** — A multi-node cluster for high availability. Set the **Number of Replicas** (e.g., `3`).
 
-![Replicaset mode selected showing the Number of Replicas field](../images/db-create/mariadb/replicaset-mode.png)
+![Replicaset mode selected showing the Number of Replicas field](../../images/db-create/mariadb/replicaset-mode.png)
 
 | Field | Description |
 |---|---|
@@ -32,8 +32,8 @@ Select the topology under **Database Mode**. Two modes are available:
 
 ## Create a MariaDB Database
 
-1. Open the wizard and select **MariaDB** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **MariaDB** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/memcached.md
+++ b/docs/platform/guides/database-management/create-database/memcached.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Memcached** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**. Two modes are available:
 - **Standalone** — A single-node instance. Best for development or low-traffic workloads.
 - **Replicaset** — A multi-node cluster for high availability. Set the **Number of Replicas** (e.g., `3`).
 
-![Replicaset mode selected showing the Number of Replicas field](../images/db-create/memcached/replicaset-mode.png)
+![Replicaset mode selected showing the Number of Replicas field](../../images/db-create/memcached/replicaset-mode.png)
 
 | Field | Description |
 |---|---|
@@ -32,8 +32,8 @@ Select the topology under **Database Mode**. Two modes are available:
 
 ## Create a Memcached Database
 
-1. Open the wizard and select **Memcached** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Memcached** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/milvus.md
+++ b/docs/platform/guides/database-management/create-database/milvus.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Milvus** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**:
 - **Standalone** — A single-node Milvus instance.
 - **Distributed** — A multi-node Milvus deployment with separated components for scale and availability.
 
-![Distributed mode selected showing component configuration](../images/db-create/milvus/mode-select.png)
+![Distributed mode selected showing component configuration](../../images/db-create/milvus/mode-select.png)
 
 | Field | Description |
 |---|---|
@@ -34,7 +34,7 @@ Select the topology under **Database Mode**:
 
 Milvus depends on a metadata store (etcd) and object storage, and exposes a few instance-level toggles.
 
-![Milvus meta storage and object storage configuration](../images/db-create/milvus/dependencies.png)
+![Milvus meta storage and object storage configuration](../../images/db-create/milvus/dependencies.png)
 
 **Meta Storage (etcd)**
 
@@ -60,8 +60,8 @@ Milvus depends on a metadata store (etcd) and object storage, and exposes a few 
 
 ## Create a Milvus Database
 
-1. Open the wizard and select **Milvus** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Milvus** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/mongodb.md
+++ b/docs/platform/guides/database-management/create-database/mongodb.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **MongoDB** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -29,7 +29,7 @@ Select the topology under **Database Mode**. Three modes are available:
 
 When **Replicated Cluster** is selected, two additional fields appear:
 
-![Replicated Cluster mode selected showing Replicaset Name (rs0) and Replicaset Number (3) fields](../images/db-create/mongodb/replicaset-mode.png)
+![Replicated Cluster mode selected showing Replicaset Name (rs0) and Replicaset Number (3) fields](../../images/db-create/mongodb/replicaset-mode.png)
 
 | Field | Description |
 |---|---|
@@ -41,11 +41,11 @@ When **Replicated Cluster** is selected, two additional fields appear:
 
 When **Sharded Cluster** is selected, three subsections appear — **Shard Nodes**, **Config Server**, and **Mongos** — each configurable independently.
 
-![Sharded Cluster mode selected showing Shard Nodes, Config Server, and Mongos collapsible panels](../images/db-create/mongodb/shard-mode.png)
+![Sharded Cluster mode selected showing Shard Nodes, Config Server, and Mongos collapsible panels](../../images/db-create/mongodb/shard-mode.png)
 
 **Shard Nodes** — Configure how MongoDB data is partitioned, replicated, and resourced across your cluster.
 
-![Shard Nodes panel showing Shards, Replicaset Number, Storage size, Machine, CPU, and Memory fields](../images/db-create/mongodb/shard-nodes.png)
+![Shard Nodes panel showing Shards, Replicaset Number, Storage size, Machine, CPU, and Memory fields](../../images/db-create/mongodb/shard-nodes.png)
 
 | Field | Description |
 |---|---|
@@ -58,7 +58,7 @@ When **Sharded Cluster** is selected, three subsections appear — **Shard Nodes
 
 **Config Server** — Stores metadata about the sharded cluster including chunk distribution and shard configuration. Must run as a replica set.
 
-![Config Server panel showing Replicaset Number, Storage size, Machine, CPU, and Memory fields](../images/db-create/mongodb/config-server.png)
+![Config Server panel showing Replicaset Number, Storage size, Machine, CPU, and Memory fields](../../images/db-create/mongodb/config-server.png)
 
 | Field | Description |
 |---|---|
@@ -70,7 +70,7 @@ When **Sharded Cluster** is selected, three subsections appear — **Shard Nodes
 
 **Mongos** — Acts as the query router for the sharded cluster, directing client requests to the appropriate shards based on metadata from Config Servers.
 
-![Mongos panel showing Replicaset number, Machine, CPU, and Memory fields](../images/db-create/mongodb/mongos-mode.png)
+![Mongos panel showing Replicaset number, Machine, CPU, and Memory fields](../../images/db-create/mongodb/mongos-mode.png)
 
 | Field | Description |
 |---|---|
@@ -81,8 +81,6 @@ When **Sharded Cluster** is selected, three subsections appear — **Shard Nodes
 
 ## Additional MongoDB Options
 
-![MongoDB arbiter and hidden node options](../images/db-create/mongodb/extra-options.png)
-
 | Field | Description |
 |---|---|
 | **Arbiter** | Toggle on to add an arbiter member (votes in elections but stores no data). Configure its pod resources. |
@@ -91,8 +89,8 @@ When **Sharded Cluster** is selected, three subsections appear — **Shard Nodes
 
 ## Create a MongoDB Database
 
-1. Open the wizard and select **MongoDB** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **MongoDB** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/mssqlserver.md
+++ b/docs/platform/guides/database-management/create-database/mssqlserver.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Microsoft SQL Server** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**:
 - **Standalone** — A single-node SQL Server instance.
 - **Topology** — A high-availability deployment using an **Availability Group**.
 
-![Topology mode selected showing Availability Group configuration](../images/db-create/mssqlserver/topology-mode.png)
+![Topology mode selected showing Availability Group configuration](../../images/db-create/mssqlserver/topology-mode.png)
 
 **Availability Group**
 
@@ -36,7 +36,7 @@ Select the topology under **Database Mode**:
 
 Microsoft SQL Server requires you to accept the licensing terms and choose a product edition.
 
-![SQL Server license acceptance and PID edition fields](../images/db-create/mssqlserver/settings.png)
+![SQL Server license acceptance and PID edition fields](../../images/db-create/mssqlserver/settings.png)
 
 | Field | Description |
 |---|---|
@@ -47,8 +47,8 @@ When **Topology** mode is used, you may also list the **Databases** to include i
 
 ## Create a Microsoft SQL Server Database
 
-1. Open the wizard and select **Microsoft SQL Server** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Microsoft SQL Server** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/mysql.md
+++ b/docs/platform/guides/database-management/create-database/mysql.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **MySQL** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -27,7 +27,7 @@ Select the topology under **Database Mode**. Available modes:
 - **SemiSync** — A semi-synchronous replication topology with configurable acknowledgement.
 - **RemoteReplica** — A replica that streams from an external/primary MySQL.
 
-![Mode options showing GroupReplication, InnoDBCluster, SemiSync, and RemoteReplica](../images/db-create/mysql/mode-select.png)
+![Mode options showing GroupReplication, InnoDBCluster, SemiSync, and RemoteReplica](../../images/db-create/mysql/mode-select.png)
 
 | Field | Description |
 |---|---|
@@ -38,8 +38,8 @@ Select the topology under **Database Mode**. Available modes:
 
 ## Create a MySQL Database
 
-1. Open the wizard and select **MySQL** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **MySQL** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/neo4j.md
+++ b/docs/platform/guides/database-management/create-database/neo4j.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Neo4j** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,15 +24,13 @@ Select the topology under **Database Mode**. Two modes are available:
 - **Standalone** — A single-node instance. Best for development or low-traffic workloads.
 - **Replicaset** — A multi-node cluster for high availability. Set the **Number of Replicas** (e.g., `3`).
 
-![Replicaset mode selected showing the Number of Replicas field](../images/db-create/neo4j/replicaset-mode.png)
+![Replicaset mode selected showing the Number of Replicas field](../../images/db-create/neo4j/replicaset-mode.png)
 
 | Field | Description |
 |---|---|
 | **Number of Replicas** | Number of nodes in the cluster (e.g., `3`). Required for Replicaset. |
 
 ## Neo4j Settings
-
-![Neo4j storage type, security, and TLS options](../images/db-create/neo4j/settings.png)
 
 | Field | Description |
 |---|---|
@@ -42,8 +40,8 @@ Select the topology under **Database Mode**. Two modes are available:
 
 ## Create a Neo4j Database
 
-1. Open the wizard and select **Neo4j** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Neo4j** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/oracle.md
+++ b/docs/platform/guides/database-management/create-database/oracle.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Oracle** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**:
 - **Standalone** — A single-node Oracle instance.
 - **DataGuard** — An Oracle Data Guard configuration with a primary and standby database for disaster recovery.
 
-![DataGuard mode selected showing Protection Mode, Sync Mode, and Standby Type](../images/db-create/oracle/mode-select.png)
+![DataGuard mode selected showing Protection Mode, Sync Mode, and Standby Type](../../images/db-create/oracle/mode-select.png)
 
 When **DataGuard** is selected:
 
@@ -38,8 +38,8 @@ When **DataGuard** is selected:
 
 ## Create a Oracle Database
 
-1. Open the wizard and select **Oracle** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Oracle** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/perconaxtradb.md
+++ b/docs/platform/guides/database-management/create-database/perconaxtradb.md
@@ -15,13 +15,13 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Percona XtraDB** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
 Percona XtraDB is deployed as a single logical instance. Set the **Number of Replicas** to control how many nodes back the instance for availability.
 
-![Replicas configuration for Percona XtraDB](../images/db-create/perconaxtradb/replicas.png)
+![Replicas configuration for Percona XtraDB](../../images/db-create/perconaxtradb/replicas.png)
 
 | Field | Description |
 |---|---|
@@ -29,8 +29,8 @@ Percona XtraDB is deployed as a single logical instance. Set the **Number of Rep
 
 ## Create a Percona XtraDB Database
 
-1. Open the wizard and select **Percona XtraDB** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Percona XtraDB** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/pgbouncer.md
+++ b/docs/platform/guides/database-management/create-database/pgbouncer.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **PgBouncer** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**. Two modes are available:
 - **Standalone** — A single-node instance. Best for development or low-traffic workloads.
 - **Replicaset** — A multi-node cluster for high availability. Set the **Number of Replicas** (e.g., `3`).
 
-![Replicaset mode selected showing the Number of Replicas field](../images/db-create/pgbouncer/replicaset-mode.png)
+![Replicaset mode selected showing the Number of Replicas field](../../images/db-create/pgbouncer/replicaset-mode.png)
 
 | Field | Description |
 |---|---|
@@ -42,8 +42,8 @@ PgBouncer pools connections to a backend PostgreSQL database.
 
 ## Create a PgBouncer Database
 
-1. Open the wizard and select **PgBouncer** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **PgBouncer** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/pgpool.md
+++ b/docs/platform/guides/database-management/create-database/pgpool.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Pgpool** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**. Two modes are available:
 - **Standalone** — A single-node instance. Best for development or low-traffic workloads.
 - **Replicaset** — A multi-node cluster for high availability. Set the **Number of Replicas** (e.g., `3`).
 
-![Replicaset mode selected showing the Number of Replicas field](../images/db-create/pgpool/replicaset-mode.png)
+![Replicaset mode selected showing the Number of Replicas field](../../images/db-create/pgpool/replicaset-mode.png)
 
 | Field | Description |
 |---|---|
@@ -41,8 +41,8 @@ Pgpool sits in front of a PostgreSQL instance for connection pooling and load ba
 
 ## Create a Pgpool Database
 
-1. Open the wizard and select **Pgpool** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Pgpool** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/postgres.md
+++ b/docs/platform/guides/database-management/create-database/postgres.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **PostgreSQL** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -25,7 +25,7 @@ Select the topology under **Database Mode**. Three modes are available:
 - **Cluster** — A primary with one or more streaming replicas for high availability. Set the **Number of Replicas**.
 - **RemoteReplica** — A replica that streams from an external/primary PostgreSQL for cross-cluster replication.
 
-![Cluster mode selected showing Number of Replicas, Standby Mode, and Streaming Mode](../images/db-create/postgres/mode-select.png)
+![Cluster mode selected showing Number of Replicas, Standby Mode, and Streaming Mode](../../images/db-create/postgres/mode-select.png)
 
 When **Cluster** is selected, configure replication behaviour:
 
@@ -37,8 +37,8 @@ When **Cluster** is selected, configure replication behaviour:
 
 ## Create a PostgreSQL Database
 
-1. Open the wizard and select **PostgreSQL** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **PostgreSQL** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/proxysql.md
+++ b/docs/platform/guides/database-management/create-database/proxysql.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **ProxySQL** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**. Two modes are available:
 - **Standalone** — A single-node instance. Best for development or low-traffic workloads.
 - **Replicaset** — A multi-node cluster for high availability. Set the **Number of Replicas** (e.g., `3`).
 
-![Replicaset mode selected showing the Number of Replicas field](../images/db-create/proxysql/replicaset-mode.png)
+![Replicaset mode selected showing the Number of Replicas field](../../images/db-create/proxysql/replicaset-mode.png)
 
 | Field | Description |
 |---|---|
@@ -41,8 +41,8 @@ ProxySQL proxies traffic to a backend MySQL-family cluster.
 
 ## Create a ProxySQL Database
 
-1. Open the wizard and select **ProxySQL** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **ProxySQL** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/qdrant.md
+++ b/docs/platform/guides/database-management/create-database/qdrant.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Qdrant** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,15 +24,13 @@ Select the topology under **Database Mode**:
 - **Standalone** — A single-node Qdrant instance.
 - **Distributed** — A multi-node Qdrant cluster that shards collections across nodes for scale and availability.
 
-![Distributed mode selected showing the Number of Replicas field](../images/db-create/qdrant/mode-select.png)
+![Distributed mode selected showing the Number of Replicas field](../../images/db-create/qdrant/mode-select.png)
 
 | Field | Description |
 |---|---|
 | **Number of Replicas** | Number of nodes in the distributed cluster (e.g., `3`). Required for Distributed. |
 
 ## Qdrant Settings
-
-![Qdrant storage type, security, and TLS options](../images/db-create/qdrant/settings.png)
 
 | Field | Description |
 |---|---|
@@ -43,8 +41,8 @@ Select the topology under **Database Mode**:
 
 ## Create a Qdrant Database
 
-1. Open the wizard and select **Qdrant** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Qdrant** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/rabbitmq.md
+++ b/docs/platform/guides/database-management/create-database/rabbitmq.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **RabbitMQ** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**. Two modes are available:
 - **Standalone** — A single-node instance. Best for development or low-traffic workloads.
 - **Replicaset** — A multi-node cluster for high availability. Set the **Number of Replicas** (e.g., `3`).
 
-![Replicaset mode selected showing the Number of Replicas field](../images/db-create/rabbitmq/replicaset-mode.png)
+![Replicaset mode selected showing the Number of Replicas field](../../images/db-create/rabbitmq/replicaset-mode.png)
 
 | Field | Description |
 |---|---|
@@ -32,8 +32,8 @@ Select the topology under **Database Mode**. Two modes are available:
 
 ## Create a RabbitMQ Database
 
-1. Open the wizard and select **RabbitMQ** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **RabbitMQ** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/redis.md
+++ b/docs/platform/guides/database-management/create-database/redis.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Redis** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -25,7 +25,7 @@ Select the topology under **Database Mode**. Three modes are available:
 - **Cluster** — A sharded Redis Cluster for horizontal scaling and high availability.
 - **Sentinel** — A primary/replica setup monitored by Redis Sentinel for automatic failover.
 
-![Cluster and Sentinel mode options](../images/db-create/redis/mode-select.png)
+![Cluster and Sentinel mode options](../../images/db-create/redis/mode-select.png)
 
 | Mode | Key fields |
 |---|---|
@@ -34,13 +34,13 @@ Select the topology under **Database Mode**. Three modes are available:
 
 ## Announce Redis Endpoints (Cluster Mode Only)
 
-> **Important — required if you plan to expose a Cluster-mode Redis externally.** The default external endpoint (via **Expose via Gateway**, see [Additional Options](common-steps.md#6-additional-options)) is a single Kubernetes Service that load-balances across *all* pods in *all* shards. Redis Cluster clients don't work well with that: a client's request is only served correctly if the pod it happens to connect to owns the requested key's slot — otherwise Redis replies with a redirect to the internal pod IP, which the external client cannot reach and the connection times out.
+> **Important — required if you plan to expose a Cluster-mode Redis externally.** The default external endpoint (via **Expose via Gateway**, see [Additional Options](../common-steps.md#6-additional-options)) is a single Kubernetes Service that load-balances across *all* pods in *all* shards. Redis Cluster clients don't work well with that: a client's request is only served correctly if the pod it happens to connect to owns the requested key's slot — otherwise Redis replies with a redirect to the internal pod IP, which the external client cannot reach and the connection times out.
 >
 > Toggling on **Announce Redis Endpoints** tells each Redis node to advertise its externally reachable address instead of its internal IP, so redirects point somewhere the client can actually connect to.
 
 If **Database Mode** is **Cluster**, an **Announce Redis Endpoints ?** toggle appears below **Storage Size**. Turn it on to reveal the **Announce** panel:
 
-![Announce Redis Endpoints toggle and Announce panel with Type and per-shard endpoints](../images/db-create/redis/announce.png)
+![Announce Redis Endpoints toggle and Announce panel with Type and per-shard endpoints](../../images/db-create/redis/announce.png)
 
 | Field | Description |
 |---|---|
@@ -57,8 +57,8 @@ For the underlying mechanism, see the [Redis External Connections guide](https:/
 
 ## Create a Redis Database
 
-1. Open the wizard and select **Redis** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database). For **Cluster** mode, configure [Announce Redis Endpoints](#announce-redis-endpoints-cluster-mode-only) if you'll expose it externally.
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Redis** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database). For **Cluster** mode, configure [Announce Redis Endpoints](#announce-redis-endpoints-cluster-mode-only) if you'll expose it externally.
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/singlestore.md
+++ b/docs/platform/guides/database-management/create-database/singlestore.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **SingleStore** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**:
 - **Standalone** — A single-node SingleStore instance.
 - **Topology** — A distributed cluster split into **Aggregator** and **Leaf** node tiers.
 
-![Topology mode selected showing Aggregator and Leaf node panels](../images/db-create/singlestore/topology-mode.png)
+![Topology mode selected showing Aggregator and Leaf node panels](../../images/db-create/singlestore/topology-mode.png)
 
 **Aggregator** — Routes queries and aggregates results.
 
@@ -50,8 +50,8 @@ SingleStore is commercial software and requires a license.
 
 ## Create a SingleStore Database
 
-1. Open the wizard and select **SingleStore** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **SingleStore** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/solr.md
+++ b/docs/platform/guides/database-management/create-database/solr.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Solr** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -25,7 +25,7 @@ Select the topology under **Database Mode**. Three modes are available:
 - **Replicaset** — A multi-node Solr cluster. Set the **Number of Replicas**.
 - **Topology** — A role-separated cluster with dedicated **Overseer**, **Data**, and **Coordinator** node tiers.
 
-![Topology mode selected showing Overseer, Data, and Coordinator node panels](../images/db-create/solr/topology-mode.png)
+![Topology mode selected showing Overseer, Data, and Coordinator node panels](../../images/db-create/solr/topology-mode.png)
 
 | Node | Description |
 |---|---|
@@ -43,13 +43,13 @@ SolrCloud requires ZooKeeper for coordination.
 |---|---|
 | **ZooKeeper Ref (Namespace / Name)** | Reference to the ZooKeeper instance Solr uses for coordination. |
 
-![Overseer, Data, Coordinator fields and Zookeeper Ref](../images/db-create/solr/fields.png)
+![Overseer, Data, Coordinator fields and Zookeeper Ref](../../images/db-create/solr/fields.png)
 
 
 ## Create a Solr Database
 
-1. Open the wizard and select **Solr** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Solr** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/weaviate.md
+++ b/docs/platform/guides/database-management/create-database/weaviate.md
@@ -15,13 +15,13 @@ section_menu_id: guides
 
 This page covers the configuration specific to **Weaviate** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
 Weaviate is deployed as a single logical instance. Set the **Number of Replicas** to control how many nodes back the instance for availability.
 
-![Replicas configuration for Weaviate](../images/db-create/weaviate/replicas.png)
+![Replicas configuration for Weaviate](../../images/db-create/weaviate/replicas.png)
 
 | Field | Description |
 |---|---|
@@ -38,8 +38,8 @@ Weaviate is deployed as a single logical instance. Set the **Number of Replicas*
 
 ## Create a Weaviate Database
 
-1. Open the wizard and select **Weaviate** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **Weaviate** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/database-management/create-database/zookeeper.md
+++ b/docs/platform/guides/database-management/create-database/zookeeper.md
@@ -15,7 +15,7 @@ section_menu_id: guides
 
 This page covers the configuration specific to **ZooKeeper** — its **Database Mode** and any engine-specific settings shown below. The rest of the creation flow —
 opening the wizard, namespace and name, version, machine profile, storage, and optional
-features — is the same for every engine and is documented in [Common Steps](common-steps.md).
+features — is the same for every engine and is documented in [Common Steps](../common-steps.md).
 
 ## Database Mode
 
@@ -24,7 +24,7 @@ Select the topology under **Database Mode**. Two modes are available:
 - **Standalone** — A single-node instance. Best for development or low-traffic workloads.
 - **Replicaset** — A multi-node cluster for high availability. Set the **Number of Replicas** (e.g., `3`).
 
-![Replicaset mode selected showing the Number of Replicas field](../images/db-create/zookeeper/replicaset-mode.png)
+![Replicaset mode selected showing the Number of Replicas field](../../images/db-create/zookeeper/replicaset-mode.png)
 
 | Field | Description |
 |---|---|
@@ -32,8 +32,8 @@ Select the topology under **Database Mode**. Two modes are available:
 
 ## Create a ZooKeeper Database
 
-1. Open the wizard and select **ZooKeeper** — see [Getting Started](common-steps.md#1-getting-started) and [Select a Database Type](common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](common-steps.md#7-deploy).
+1. Open the wizard and select **ZooKeeper** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps.md#7-deploy).

--- a/docs/platform/guides/get-started/add-cluster.md
+++ b/docs/platform/guides/get-started/add-cluster.md
@@ -23,6 +23,6 @@ Follow these steps to import your Kubernetes cluster:
 4. Select the credentials you added in the previous step.
 5. Follow the provider-specific instructions to complete the import process.
 
-For detailed instructions and troubleshooting tips, refer to our comprehensive [Import Kubernetes Cluster Guide](../cluster-management/add-cluster/overview.md).
+For detailed instructions and troubleshooting tips, refer to our comprehensive [Import Kubernetes Cluster Guide](../../cluster-management/add-cluster/overview.md).
 
 Once your cluster is imported, you can explore its details and capabilities directly from the Platform Console.

--- a/docs/platform/guides/get-started/add-credential.md
+++ b/docs/platform/guides/get-started/add-credential.md
@@ -21,6 +21,6 @@ Follow these steps to add your credentials:
 2. Choose your `Credential Type` or authentication method and enter the required details.
 3. Click on the `Done` button to securely save your credentials.
 
-For detailed documentation refer to [Credential Management](../account-management/kubernetes/credentials.md)
+For detailed documentation refer to [Credential Management](../../account-management/kubernetes/credentials.md)
 
 After adding your credentials, you'll be ready to import your Kubernetes cluster and unlock a world of possibilities within the platform.

--- a/docs/platform/guides/get-started/enable-features.md
+++ b/docs/platform/guides/get-started/enable-features.md
@@ -23,4 +23,4 @@ Once your cluster is imported, you can enable or disable KubeDB Platform feature
 
 Managing features in the Platform Console is a straightforward process that allows you to tailor your Platform Console to meet your cluster's requirements. Feel free to explore the features and capabilities offered by KubeDB Platform.
 
-For more advanced configurations and detailed documentation, check out the [Features in Details](../cluster-management/cluster-features.md).
+For more advanced configurations and detailed documentation, check out the [Features in Details](../../cluster-management/cluster-features.md).

--- a/docs/platform/selfhost-setup/README.md
+++ b/docs/platform/selfhost-setup/README.md
@@ -19,19 +19,19 @@ Welcome to KubeDB Platform's Self-Hosted deployment! Whether you're looking for 
 
 Navigate to [KubeDB Platform Self-Hosted](https://appscode.com/selfhost). Here you will find your previously generated self-hosted installers.
 
-![Installer Home](images/installer-home.png)
+![Installer Home](../images/installer-home.png)
 <br/>
 
 <br/>
 
-Click on the `Create New Installer` button to get started. You can either choose deployment type `Self Hosted Demo` or `Self Hosted Production`. Provide the required data and click `Done` button to generate the installer. Upon generation of the installer, you will get the documentation how to host KubeDB Platform Server on your own.
+Click on the `Create New Installer` button to get started. You can choose various deployment types including `Cloud Demo` or `Self Hosted Production`. Provide the required data and click `Done` button to generate the installer. Upon generation of the installer, you will get the documentation how to host KubeDB Platform Server on your own.
 <br/>
 
 <br/>
 
-To get detailed documentation on `Self Hosted Demo` installer, head over to [Demo Deployment](install/selfhosted-demo.md).
+To get detailed documentation on `Cloud Demo` installer, head over to [Demo Deployment](../install/cloud-demo.md).
 <br/>
 
 <br/>
 
-To get detailed documentation on `Self Hosted Production` installer, head over to [Production Deployment](install/selfhosted-production.md).
+To get detailed documentation on `Self Hosted Production` installer, head over to [Production Deployment](../install/selfhosted-production.md).

--- a/docs/platform/selfhost-setup/install/aws-marketplace.md
+++ b/docs/platform/selfhost-setup/install/aws-marketplace.md
@@ -18,7 +18,7 @@ To install **KubeDB Platform**, you need to have the permissions to manage **EC2
 
 ### Prerequisite
 
-See [Prerequisites](common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
+See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
 
 You have to create an `Access Key` and `Secret Key` with following policies attached. Check out similar [eksctl docs](https://eksctl.io/usage/minimum-iam-policies/) for reference. 
 
@@ -263,11 +263,11 @@ These credentials define the primary super-user and the initial organizational s
 For openshift cluster toggle Red Hat OpenShift cluster and give Kube API Server endpoint 
 
 ### 4. Registry
-See [Registry](common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
+See [Registry](../common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
 
 ### 5. Monitoring
 
-See [Monitoring](common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
+See [Monitoring](../common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
 
 
 ### 6. Settings
@@ -282,7 +282,7 @@ In this section you can enable or disable features. You can also create an initi
 
 
 ### 8. Branding & UI Customization
-See [Branding & UI Customization](common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
+See [Branding & UI Customization](../common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
 
 ### 9. Generate Installer and Documentation
 

--- a/docs/platform/selfhost-setup/install/azure-marketplace.md
+++ b/docs/platform/selfhost-setup/install/azure-marketplace.md
@@ -16,7 +16,7 @@ Welcome to the KubeDB Platform's **Azure Marketplace** deployment! This guide wi
 
 ### Prerequisites
 
-See [Prerequisites](common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
+See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
 
 ## Getting Started
 
@@ -66,17 +66,17 @@ Put **Subscription ID**, **Tenant ID**, **Client ID** and **Client Secret** in t
 
 ### 4. Global Administrative Settings
 
-See [Global Administrative Settings](common-config.md#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
+See [Global Administrative Settings](../common-config.md#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
 
 For openshift cluster toggle Red Hat OpenShift cluster and give Kube API Server endpoint 
 
 ### 5. Registry
 
-See [Registry](common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
+See [Registry](../common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
 
 ### 6. Monitoring
 
-See [Monitoring](common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
+See [Monitoring](../common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
 
 ### 7. Settings
 
@@ -94,7 +94,7 @@ In this section you can enable or disable features.  You can also create an init
 
 ### 9. Branding & UI Customization
 
-See [Branding & UI Customization](common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
+See [Branding & UI Customization](../common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
 
 ### 10. Generate Installer and Documentation
 

--- a/docs/platform/selfhost-setup/install/cloud-demo.md
+++ b/docs/platform/selfhost-setup/install/cloud-demo.md
@@ -16,7 +16,7 @@ Welcome to the KubeDB Platform's "Cloud Demo" deployment! Follow these steps to 
 
 ### Prerequisites
 
-See [Prerequisites](common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note. 
+See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note. 
 
 ### 1. Visit the KubeDB Platform Self-Hosted Page
 
@@ -34,38 +34,38 @@ Before beginning the installation, identify your target infrastructure and clust
   * **Target IP:** Provide the static IP addresses for your cluster nodes or load balancer.
 * **Cluster Type:** Determine if you are installing on **AWS EKS Cluster** or **Red Hat OpenShift Cluster**.
 
-> For Red Hat OpenShift clusters, see the [Deploying KubeDB Platform in OpenShift Cluster](openshift-cluster.md) guide.
+> For Red Hat OpenShift clusters, see the [Deploying KubeDB Platform in OpenShift Cluster](../openshift-cluster.md) guide.
 
 #### Additional configuration for EKS cluster
 
-See [Additional configuration for EKS cluster](common-config.md#additional-configuration-for-eks-cluster) in the Common Configuration guide for the EBS CSI / AWS Load Balancer Controller prerequisites and the commands to fetch the Kube API server endpoint, subnet IDs, and EIP allocation IDs.
+See [Additional configuration for EKS cluster](../common-config.md#additional-configuration-for-eks-cluster) in the Common Configuration guide for the EBS CSI / AWS Load Balancer Controller prerequisites and the commands to fetch the Kube API server endpoint, subnet IDs, and EIP allocation IDs.
 
 ### 3. Global Administrative Settings
-See [Global Administrative Settings](common-config.md#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
+See [Global Administrative Settings](../common-config.md#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
 
 ### 4. Registry
-See [Registry](common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
+See [Registry](../common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
 
 ### 5. Monitoring
 
-See [Monitoring](common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
+See [Monitoring](../common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
 
 
 ### 6. Settings
 
 #### Domain White List and Proxy Servers
 
-See [Domain White List and Proxy Servers](common-config.md#domain-white-list-and-proxy-servers) in the Common Configuration guide for whitelisting domains, proxy servers, and login/logout URLs.
+See [Domain White List and Proxy Servers](../common-config.md#domain-white-list-and-proxy-servers) in the Common Configuration guide for whitelisting domains, proxy servers, and login/logout URLs.
 
 ### 7. Ingress & Gateway
 
-See [Ingress & Gateway](common-config.md#ingress--gateway) in the Common Configuration guide for exposing the platform via the Gateway API or standard Ingress.
+See [Ingress & Gateway](../common-config.md#ingress--gateway) in the Common Configuration guide for exposing the platform via the Gateway API or standard Ingress.
 
 ### 8. Self Management
-See [Self Management](common-config.md#self-management) in the Common Configuration guide to enable or disable platform features.
+See [Self Management](../common-config.md#self-management) in the Common Configuration guide to enable or disable platform features.
 
 ### 9. Branding & UI Customization
-See [Branding & UI Customization](common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
+See [Branding & UI Customization](../common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
 
 ### 10. Generate Installer and Documentation
 

--- a/docs/platform/selfhost-setup/install/offline.md
+++ b/docs/platform/selfhost-setup/install/offline.md
@@ -18,7 +18,7 @@ In offline mode, AppsCode never receives any of your KubeDB usage data. AppsCode
 
 ### Prerequisites
 
-See [Prerequisites](common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
+See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
 
 ### 1. Visit the KubeDB Platform Self-Hosted Page
 
@@ -45,7 +45,7 @@ This is the requirement that distinguishes an offline deployment from a standard
 
 ### 4. Complete the Remaining Configuration
 
-Aside from enabling the offline toggle and providing the Cluster ID, all other sections are identical to a standard Self Hosted Production deployment (Global Administrative Settings, Release, Registry, Settings, Monitoring, Infra, TLS, Ingress & Gateway, NATS, and more). For the complete field-by-field walkthrough, follow the [Self Hosted Production](selfhosted-production.md) guide.
+Aside from enabling the offline toggle and providing the Cluster ID, all other sections are identical to a standard Self Hosted Production deployment (Global Administrative Settings, Release, Registry, Settings, Monitoring, Infra, TLS, Ingress & Gateway, NATS, and more). For the complete field-by-field walkthrough, follow the [Self Hosted Production](../selfhosted-production.md) guide.
 
 ### 5. Generate Installer and Documentation
 

--- a/docs/platform/selfhost-setup/install/onprem-demo.md
+++ b/docs/platform/selfhost-setup/install/onprem-demo.md
@@ -16,7 +16,7 @@ Welcome to the KubeDB Platform's "Onprem Demo" deployment! Follow these steps to
 
 ### Prerequisites
 
-See [Prerequisites](common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note. 
+See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note. 
 
 ### 1. Visit the KubeDB Platform Self-Hosted Page
 
@@ -34,41 +34,41 @@ Before beginning the installation, identify your target infrastructure and clust
   * **Target IP:** Provide the static IP addresses for your cluster nodes or load balancer.
 * **Cluster Type:** Determine if you are installing on **Red Hat OpenShift Cluster**.
 
-> For Red Hat OpenShift clusters, see the [Deploying KubeDB Platform in OpenShift Cluster](openshift-cluster.md) guide.
+> For Red Hat OpenShift clusters, see the [Deploying KubeDB Platform in OpenShift Cluster](../openshift-cluster.md) guide.
 
 ### 3. Global Administrative Settings
-See [Global Administrative Settings](common-config.md#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
+See [Global Administrative Settings](../common-config.md#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
 
 ### 4. Registry
-See [Registry](common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
+See [Registry](../common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
 
 ### 5. Monitoring
 
-See [Monitoring](common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
+See [Monitoring](../common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
 
 
 ### 6. Settings
 
 #### Domain White List and Proxy Servers
 
-See [Domain White List and Proxy Servers](common-config.md#domain-white-list-and-proxy-servers) in the Common Configuration guide for whitelisting domains, proxy servers, and login/logout URLs.
+See [Domain White List and Proxy Servers](../common-config.md#domain-white-list-and-proxy-servers) in the Common Configuration guide for whitelisting domains, proxy servers, and login/logout URLs.
 
 ### 7. TLS
-See [TLS](common-config.md#tls) in the Common Configuration guide for configuring the certificate issuer (External or CA).
+See [TLS](../common-config.md#tls) in the Common Configuration guide for configuring the certificate issuer (External or CA).
 
 ### 8. Ingress & Gateway
 
-See [Ingress & Gateway](common-config.md#ingress--gateway) in the Common Configuration guide for exposing the platform via the Gateway API or standard Ingress.
+See [Ingress & Gateway](../common-config.md#ingress--gateway) in the Common Configuration guide for exposing the platform via the Gateway API or standard Ingress.
 
 ### 9. NATS
 
-See [NATS](common-config.md#nats) in the Common Configuration guide for configuring the internal messaging system (expose method, replicas, and resources).
+See [NATS](../common-config.md#nats) in the Common Configuration guide for configuring the internal messaging system (expose method, replicas, and resources).
 
 ### 10. Self Management
-See [Self Management](common-config.md#self-management) in the Common Configuration guide to enable or disable platform features.
+See [Self Management](../common-config.md#self-management) in the Common Configuration guide to enable or disable platform features.
 
 ### 11. Branding & UI Customization
-See [Branding & UI Customization](common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
+See [Branding & UI Customization](../common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
 
 ### 12. Generate Installer and Documentation
 

--- a/docs/platform/selfhost-setup/install/openshift-cluster.md
+++ b/docs/platform/selfhost-setup/install/openshift-cluster.md
@@ -21,7 +21,7 @@ Regardless of the mode, an OpenShift deployment always requires you to toggle th
 
 ### Prerequisites
 
-See [Prerequisites](common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
+See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
 
 ### 1. Visit the KubeDB Platform Self-Hosted Page
 
@@ -64,7 +64,7 @@ Use this mode when you want to reach the platform through a static IP instead of
 > [!IMPORTANT]
 > The LoadBalancer IP is not known yet, so the random Target IP must be fixed later (see [Deploy KubeDB Platform](#5-deploy-kubedb-platform)).
 
-Once OpenShift is enabled and the Kube API Server is set, follow the standard configuration sections for the deployment type you picked. See the [Cloud Demo](cloud-demo.md) or [Onprem Demo](onprem-demo.md) guide for the full walkthrough of these sections.
+Once OpenShift is enabled and the Kube API Server is set, follow the standard configuration sections for the deployment type you picked. See the [Cloud Demo](../cloud-demo.md) or [Onprem Demo](../onprem-demo.md) guide for the full walkthrough of these sections.
 
 #### DNS mode (DNS preferred)
 
@@ -77,13 +77,13 @@ Use this mode when you want to reach the platform through a DNS name. In this mo
 > [!IMPORTANT]
 > The LoadBalancer IP is not known yet, so the random Target IP and the DNS `A` record must be fixed later (see [Deploy KubeDB Platform](#5-deploy-kubedb-platform)).
 
-Once OpenShift is enabled and the Kube API Server is set, follow the standard configuration sections for the deployment type you picked. See the [Onprem Demo](onprem-demo.md) or [Self Hosted Production](selfhosted-production.md) guide for the full walkthrough of these sections.
+Once OpenShift is enabled and the Kube API Server is set, follow the standard configuration sections for the deployment type you picked. See the [Onprem Demo](../onprem-demo.md) or [Self Hosted Production](../selfhosted-production.md) guide for the full walkthrough of these sections.
 
 > [!NOTE]
 > This guide only covers the fields that are **specific to an OpenShift deployment**. Each deployment type has many more configuration sections (Global Administrative Settings, Registry, Monitoring, TLS, Ingress & Gateway, NATS, and more). For the complete field-by-field walkthrough, follow the guide for the deployment type you choose:
-> * **[Cloud Demo](cloud-demo.md)**
-> * **[Onprem Demo](onprem-demo.md)**
-> * **[Self Hosted Production](selfhosted-production.md)**
+> * **[Cloud Demo](../cloud-demo.md)**
+> * **[Onprem Demo](../onprem-demo.md)**
+> * **[Self Hosted Production](../selfhosted-production.md)**
 
 ### 4. Generate Installer and Documentation
 

--- a/docs/platform/selfhost-setup/install/selfhosted-production.md
+++ b/docs/platform/selfhost-setup/install/selfhosted-production.md
@@ -30,7 +30,7 @@ This guide provides a structured approach to deploying the platform manually. We
 
 > **Note:** Ensure your infrastructure meets the minimum system requirements before proceeding to the configuration steps.
 
-See [Prerequisites](common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note. 
+See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note. 
 
 
 ### 1. Visit the KubeDB Platform Self-Hosted Page
@@ -47,7 +47,7 @@ Before beginning the installation, identify your target infrastructure and clust
 * **DNS & Connectivity:** 
   * **Enable DNS:** Toggle this to allow the installer to manage or integrate with your DNS provider.
   * **Target IP:** Provide the static IP addresses for your cluster nodes or load balancer.
-* **Cluster Type:** Determine if you are installing on **AWS EKS Cluster** or **Red Hat OpenShift Cluster**. For openshift cluster toggle Red Hat OpenShift cluster and give Kube API Server endpoint. See the [Deploying KubeDB Platform in OpenShift Cluster](openshift-cluster.md) guide.
+* **Cluster Type:** Determine if you are installing on **AWS EKS Cluster** or **Red Hat OpenShift Cluster**. For openshift cluster toggle Red Hat OpenShift cluster and give Kube API Server endpoint. See the [Deploying KubeDB Platform in OpenShift Cluster](../openshift-cluster.md) guide.
 * **Credential-Less Mode:** Enable this if you are using IAM roles for service accounts (IRSA) to avoid manual secret management.
 <br/>
 
@@ -55,7 +55,7 @@ Before beginning the installation, identify your target infrastructure and clust
 
 ### Additional configuration for EKS cluster
 
-See [Additional configuration for EKS cluster](common-config.md#additional-configuration-for-eks-cluster) in the Common Configuration guide for the EBS CSI / AWS Load Balancer Controller prerequisites and the commands to fetch the Kube API server endpoint, subnet IDs, and EIP allocation IDs.
+See [Additional configuration for EKS cluster](../common-config.md#additional-configuration-for-eks-cluster) in the Common Configuration guide for the EBS CSI / AWS Load Balancer Controller prerequisites and the commands to fetch the Kube API server endpoint, subnet IDs, and EIP allocation IDs.
 
 ### Configuring AWS credentialless mode
 
@@ -169,7 +169,7 @@ aws eks associate-access-policy \
 Provide the output role arn as Ace Installer Role ARN `echo $ROLE_ARN`in the **Ace Installer Role ARN** field. 
 
 ### 3. Global Administrative Settings
-See [Global Administrative Settings](common-config.md#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
+See [Global Administrative Settings](../common-config.md#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
 
 ### 4. Release
 Define the specific Kubernetes namespace and release information for the KubeDB Platform components.
@@ -179,7 +179,7 @@ Define the specific Kubernetes namespace and release information for the KubeDB 
 * **Namespace Automation:** Toggle **"Create namespaces during Helm install"** if you want the installer to handle namespace lifecycle management.
 
 ### 5. Registry
-See [Registry](common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
+See [Registry](../common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
 
 ### 6. Settings
 This secton is for Persistence & Resource Allocation. Properly sizing your resources is critical for production stability. Configure CPU Requests, CPU Limits, Memory Request and  Memory Limit for both cache and Database
@@ -193,7 +193,7 @@ This secton is for Persistence & Resource Allocation. Properly sizing your resou
 
 #### Domain White List and Proxy Servers
 
-See [Domain White List and Proxy Servers](common-config.md#domain-white-list-and-proxy-servers) in the Common Configuration guide for whitelisting domains, proxy servers, and login/logout URLs.
+See [Domain White List and Proxy Servers](../common-config.md#domain-white-list-and-proxy-servers) in the Common Configuration guide for whitelisting domains, proxy servers, and login/logout URLs.
 
 
 #### KubeStash
@@ -205,7 +205,7 @@ KubeDB Platform uses **KubeStash** for automated backups and disaster recovery.
 
 ### 7. Monitoring
 
-See [Monitoring](common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
+See [Monitoring](../common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
 
 ### 8. Infra 
 
@@ -224,17 +224,17 @@ See [Monitoring](common-config.md#monitoring) in the Common Configuration guide 
   * **letsencrypt-staging:** Use this for testing your installation
 
 ### 9. Ingress & Gateway
-See [Ingress & Gateway](common-config.md#ingress--gateway) in the Common Configuration guide for exposing the platform via the Gateway API or standard Ingress.
+See [Ingress & Gateway](../common-config.md#ingress--gateway) in the Common Configuration guide for exposing the platform via the Gateway API or standard Ingress.
 
 ### 10. NATS
 
-See [NATS](common-config.md#nats) in the Common Configuration guide for configuring the internal messaging system (expose method, replicas, and resources).
+See [NATS](../common-config.md#nats) in the Common Configuration guide for configuring the internal messaging system (expose method, replicas, and resources).
 
 ### 11. Self Management
-See [Self Management](common-config.md#self-management) in the Common Configuration guide to enable or disable platform features.
+See [Self Management](../common-config.md#self-management) in the Common Configuration guide to enable or disable platform features.
 
 ### 12. Branding & UI Customization
-See [Branding & UI Customization](common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
+See [Branding & UI Customization](../common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
 
 ### 13. Generate Installer and Documentation
 


### PR DESCRIPTION
## What
Normalize every relative local reference in the docs to carry **exactly one extra `../`** vs. the source filesystem path — the convention `liche` will strip one leading `../` before checking existence.

- **Images:** prepended `../` to 106 links missing it (299 already had it). Removed 5 dangling image refs pointing at screenshots that don't exist (druid/dependencies, db2/replicas, qdrant/settings, neo4j/settings, mongodb/extra-options) — no correct substitute image existed.
- **Page/`.md` links:** added the extra `../` to 365 links (`./x` normalized to `../x`). Fixed broken `install/selfhosted-demo.md` → `install/cloud-demo.md`.

Verified: all 770 local refs now resolve after stripping one `../` (0 missing, 0 broken).

## ⚠️ Requires liche patch before CI passes
This PR is docs-only. `liche` is **not** yet patched, so the CI link check will fail on the extra `../` until `appscode-cloud`/`appscodelabs/liche` is updated to strip one leading `../` for local refs and the release is bumped in `.github/workflows/ci.yml`.