### PR TITLE
docs: sort create-database engines alphabetically and update weights

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,11 @@ jobs:
 
       - name: Check links
         run: |
-          liche -r docs -d $(pwd) -c 10 -p -h -l -s -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$'
+          liche -r docs -d $(pwd) -c 10 -p -h -l -s -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*portal.azure.com.*)$'
           max_retries=5
           retry_count=0
           while [ $retry_count -lt $max_retries ]; do
-            if liche -r docs -d $(pwd) -c 10 -p -h -l -s -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$'; then
+            if liche -r docs -d $(pwd) -c 10 -p -h -l -s -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*portal.azure.com.*)$'; then
               echo "Link check passed"
               exit 0
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
 
       - name: Install link checker
         run: |
-          curl -fsSL -o liche https://github.com/appscodelabs/liche/releases/download/v0.2.0/liche-linux-amd64
-          chmod +x liche
+          git clone --depth 1 -b arnob-strip-prefix https://github.com/appscodelabs/liche.git /tmp/liche
+          cd /tmp/liche
+          go build -o liche .
           sudo mv liche /usr/local/bin/liche
 
       - name: Create Kubernetes cluster

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,11 @@ jobs:
 
       - name: Check links
         run: |
-          liche -r docs -d $(pwd) -c 10 -p -h -l -s -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*portal.azure.com.*)$'
+          liche -r docs -d $(pwd) -c 10 -p -h -l -s -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*portal.azure.com.*|.*vultr.com.*)$'
           max_retries=5
           retry_count=0
           while [ $retry_count -lt $max_retries ]; do
-            if liche -r docs -d $(pwd) -c 10 -p -h -l -s -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*portal.azure.com.*)$'; then
+            if liche -r docs -d $(pwd) -c 10 -p -h -l -s -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*portal.azure.com.*|.*vultr.com.*)$'; then
               echo "Link check passed"
               exit 0
             fi

--- a/docs/platform/guides/account-management/kubernetes/credentials.md
+++ b/docs/platform/guides/account-management/kubernetes/credentials.md
@@ -421,7 +421,7 @@ To access Scaleway resources, you need your Organization ID and an API secret ke
 - **Organization:** Your Scaleway Organization ID (a UUID), found under **Organization Settings** in the Scaleway Console.
 - **Token:** Your API Secret Key. Navigate to **Identity and Access Management (IAM) > API Keys**, create a new API key, and copy the **Secret Key**.
 
-Ref: [Scaleway API Keys](https://www.scaleway.com/en/docs/iam/api-keys/)
+Ref: [Scaleway API Keys](https://www.scaleway.com/en/docs/iam/how-to/create-api-keys/)
 
 Then add the credential [here](https://appscode.com/id/{user}/user/settings/credentials/create).
 

--- a/docs/platform/guides/database-management/create-database/_index.md
+++ b/docs/platform/guides/database-management/create-database/_index.md
@@ -26,31 +26,31 @@ it, then follow the common steps for everything else.
 ## Supported Engines
 
 ### Relational
-- [PostgreSQL](../postgres.md)
-- [MySQL](../mysql.md)
-- [MariaDB](../mariadb.md)
-- [Percona XtraDB](../perconaxtradb.md)
-- [Microsoft SQL Server](../mssqlserver.md)
-- [Oracle](../oracle.md)
-- [SingleStore](../singlestore.md)
 - [IBM Db2](../db2.md)
+- [MariaDB](../mariadb.md)
+- [Microsoft SQL Server](../mssqlserver.md)
+- [MySQL](../mysql.md)
+- [Oracle](../oracle.md)
+- [Percona XtraDB](../perconaxtradb.md)
+- [PostgreSQL](../postgres.md)
 - [SAP HANA](../hanadb.md)
+- [SingleStore](../singlestore.md)
 
 ### Document & Search
-- [MongoDB](../mongodb.md)
-- [Elasticsearch](../elasticsearch.md)
-- [Solr](../solr.md)
 - [DocumentDB](../documentdb.md)
+- [Elasticsearch](../elasticsearch.md)
+- [MongoDB](../mongodb.md)
+- [Solr](../solr.md)
 
 ### Key-Value & Cache
-- [Redis](../redis.md)
-- [Memcached](../memcached.md)
-- [Ignite](../ignite.md)
 - [Hazelcast](../hazelcast.md)
+- [Ignite](../ignite.md)
+- [Memcached](../memcached.md)
+- [Redis](../redis.md)
 
 ### Vector
-- [Qdrant](../qdrant.md)
 - [Milvus](../milvus.md)
+- [Qdrant](../qdrant.md)
 - [Weaviate](../weaviate.md)
 
 ### Wide-column & Time-series

--- a/docs/platform/guides/database-management/create-database/cassandra.md
+++ b/docs/platform/guides/database-management/create-database/cassandra.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-cassandra
     name: Cassandra
     parent: database-management-create
-    weight: 210
+    weight: 220
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/cassandra.md
+++ b/docs/platform/guides/database-management/create-database/cassandra.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-cassandra
     name: Cassandra
     parent: database-management-create
-    weight: 220
+    weight: 20
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/clickhouse.md
+++ b/docs/platform/guides/database-management/create-database/clickhouse.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-clickhouse
     name: ClickHouse
     parent: database-management-create
-    weight: 230
+    weight: 30
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/clickhouse.md
+++ b/docs/platform/guides/database-management/create-database/clickhouse.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-clickhouse
     name: ClickHouse
     parent: database-management-create
-    weight: 220
+    weight: 230
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/db2.md
+++ b/docs/platform/guides/database-management/create-database/db2.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-db2
     name: IBM Db2
     parent: database-management-create
-    weight: 20
+    weight: 80
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/db2.md
+++ b/docs/platform/guides/database-management/create-database/db2.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-db2
     name: IBM Db2
     parent: database-management-create
-    weight: 90
+    weight: 20
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/documentdb.md
+++ b/docs/platform/guides/database-management/create-database/documentdb.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-documentdb
     name: DocumentDB
     parent: database-management-create
-    weight: 110
+    weight: 40
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/documentdb.md
+++ b/docs/platform/guides/database-management/create-database/documentdb.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-documentdb
     name: DocumentDB
     parent: database-management-create
-    weight: 130
+    weight: 110
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/druid.md
+++ b/docs/platform/guides/database-management/create-database/druid.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-druid
     name: Druid
     parent: database-management-create
-    weight: 230
+    weight: 240
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/druid.md
+++ b/docs/platform/guides/database-management/create-database/druid.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-druid
     name: Druid
     parent: database-management-create
-    weight: 240
+    weight: 50
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/elasticsearch.md
+++ b/docs/platform/guides/database-management/create-database/elasticsearch.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-elasticsearch
     name: Elasticsearch
     parent: database-management-create
-    weight: 110
+    weight: 120
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/elasticsearch.md
+++ b/docs/platform/guides/database-management/create-database/elasticsearch.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-elasticsearch
     name: Elasticsearch
     parent: database-management-create
-    weight: 120
+    weight: 60
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/hanadb.md
+++ b/docs/platform/guides/database-management/create-database/hanadb.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-hanadb
     name: SAP HANA
     parent: database-management-create
-    weight: 100
+    weight: 90
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/hanadb.md
+++ b/docs/platform/guides/database-management/create-database/hanadb.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-hanadb
     name: SAP HANA
     parent: database-management-create
-    weight: 90
+    weight: 270
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/hazelcast.md
+++ b/docs/platform/guides/database-management/create-database/hazelcast.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-hazelcast
     name: Hazelcast
     parent: database-management-create
-    weight: 150
+    weight: 70
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/hazelcast.md
+++ b/docs/platform/guides/database-management/create-database/hazelcast.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-hazelcast
     name: Hazelcast
     parent: database-management-create
-    weight: 170
+    weight: 150
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/ignite.md
+++ b/docs/platform/guides/database-management/create-database/ignite.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-ignite
     name: Ignite
     parent: database-management-create
-    weight: 160
+    weight: 90
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/kafka.md
+++ b/docs/platform/guides/database-management/create-database/kafka.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-kafka
     name: Kafka
     parent: database-management-create
-    weight: 250
+    weight: 100
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/kafka.md
+++ b/docs/platform/guides/database-management/create-database/kafka.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-kafka
     name: Kafka
     parent: database-management-create
-    weight: 240
+    weight: 250
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/mariadb.md
+++ b/docs/platform/guides/database-management/create-database/mariadb.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-mariadb
     name: MariaDB
     parent: database-management-create
-    weight: 30
+    weight: 110
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/mariadb.md
+++ b/docs/platform/guides/database-management/create-database/mariadb.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-mariadb
     name: MariaDB
     parent: database-management-create
-    weight: 40
+    weight: 30
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/memcached.md
+++ b/docs/platform/guides/database-management/create-database/memcached.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-memcached
     name: Memcached
     parent: database-management-create
-    weight: 170
+    weight: 120
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/memcached.md
+++ b/docs/platform/guides/database-management/create-database/memcached.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-memcached
     name: Memcached
     parent: database-management-create
-    weight: 150
+    weight: 170
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/milvus.md
+++ b/docs/platform/guides/database-management/create-database/milvus.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-milvus
     name: Milvus
     parent: database-management-create
-    weight: 190
+    weight: 140
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/mongodb.md
+++ b/docs/platform/guides/database-management/create-database/mongodb.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-mongodb
     name: MongoDB
     parent: database-management-create
-    weight: 130
+    weight: 150
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/mongodb.md
+++ b/docs/platform/guides/database-management/create-database/mongodb.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-mongodb
     name: MongoDB
     parent: database-management-create
-    weight: 10
+    weight: 130
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/mssqlserver.md
+++ b/docs/platform/guides/database-management/create-database/mssqlserver.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-mssqlserver
     name: Microsoft SQL Server
     parent: database-management-create
-    weight: 60
+    weight: 40
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/mssqlserver.md
+++ b/docs/platform/guides/database-management/create-database/mssqlserver.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-mssqlserver
     name: Microsoft SQL Server
     parent: database-management-create
-    weight: 40
+    weight: 130
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/mysql.md
+++ b/docs/platform/guides/database-management/create-database/mysql.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-mysql
     name: MySQL
     parent: database-management-create
-    weight: 30
+    weight: 50
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/mysql.md
+++ b/docs/platform/guides/database-management/create-database/mysql.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-mysql
     name: MySQL
     parent: database-management-create
-    weight: 50
+    weight: 160
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/neo4j.md
+++ b/docs/platform/guides/database-management/create-database/neo4j.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-neo4j
     name: Neo4j
     parent: database-management-create
-    weight: 260
+    weight: 270
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/neo4j.md
+++ b/docs/platform/guides/database-management/create-database/neo4j.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-neo4j
     name: Neo4j
     parent: database-management-create
-    weight: 270
+    weight: 170
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/oracle.md
+++ b/docs/platform/guides/database-management/create-database/oracle.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-oracle
     name: Oracle
     parent: database-management-create
-    weight: 70
+    weight: 60
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/oracle.md
+++ b/docs/platform/guides/database-management/create-database/oracle.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-oracle
     name: Oracle
     parent: database-management-create
-    weight: 60
+    weight: 180
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/perconaxtradb.md
+++ b/docs/platform/guides/database-management/create-database/perconaxtradb.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-perconaxtradb
     name: Percona XtraDB
     parent: database-management-create
-    weight: 50
+    weight: 70
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/perconaxtradb.md
+++ b/docs/platform/guides/database-management/create-database/perconaxtradb.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-perconaxtradb
     name: Percona XtraDB
     parent: database-management-create
-    weight: 70
+    weight: 190
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/pgbouncer.md
+++ b/docs/platform/guides/database-management/create-database/pgbouncer.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-pgbouncer
     name: PgBouncer
     parent: database-management-create
-    weight: 280
+    weight: 290
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/pgbouncer.md
+++ b/docs/platform/guides/database-management/create-database/pgbouncer.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-pgbouncer
     name: PgBouncer
     parent: database-management-create
-    weight: 290
+    weight: 200
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/pgpool.md
+++ b/docs/platform/guides/database-management/create-database/pgpool.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-pgpool
     name: Pgpool
     parent: database-management-create
-    weight: 300
+    weight: 210
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/pgpool.md
+++ b/docs/platform/guides/database-management/create-database/pgpool.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-pgpool
     name: Pgpool
     parent: database-management-create
-    weight: 290
+    weight: 300
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/postgres.md
+++ b/docs/platform/guides/database-management/create-database/postgres.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-postgres
     name: PostgreSQL
     parent: database-management-create
-    weight: 80
+    weight: 220
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/postgres.md
+++ b/docs/platform/guides/database-management/create-database/postgres.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-postgres
     name: PostgreSQL
     parent: database-management-create
-    weight: 20
+    weight: 80
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/proxysql.md
+++ b/docs/platform/guides/database-management/create-database/proxysql.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-proxysql
     name: ProxySQL
     parent: database-management-create
-    weight: 310
+    weight: 230
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/proxysql.md
+++ b/docs/platform/guides/database-management/create-database/proxysql.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-proxysql
     name: ProxySQL
     parent: database-management-create
-    weight: 300
+    weight: 310
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/qdrant.md
+++ b/docs/platform/guides/database-management/create-database/qdrant.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-qdrant
     name: Qdrant
     parent: database-management-create
-    weight: 200
+    weight: 240
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/qdrant.md
+++ b/docs/platform/guides/database-management/create-database/qdrant.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-qdrant
     name: Qdrant
     parent: database-management-create
-    weight: 180
+    weight: 200
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/rabbitmq.md
+++ b/docs/platform/guides/database-management/create-database/rabbitmq.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-rabbitmq
     name: RabbitMQ
     parent: database-management-create
-    weight: 260
+    weight: 250
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/rabbitmq.md
+++ b/docs/platform/guides/database-management/create-database/rabbitmq.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-rabbitmq
     name: RabbitMQ
     parent: database-management-create
-    weight: 250
+    weight: 260
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/redis.md
+++ b/docs/platform/guides/database-management/create-database/redis.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-redis
     name: Redis
     parent: database-management-create
-    weight: 180
+    weight: 260
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/redis.md
+++ b/docs/platform/guides/database-management/create-database/redis.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-redis
     name: Redis
     parent: database-management-create
-    weight: 140
+    weight: 180
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/singlestore.md
+++ b/docs/platform/guides/database-management/create-database/singlestore.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-singlestore
     name: SingleStore
     parent: database-management-create
-    weight: 80
+    weight: 100
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/singlestore.md
+++ b/docs/platform/guides/database-management/create-database/singlestore.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-singlestore
     name: SingleStore
     parent: database-management-create
-    weight: 100
+    weight: 280
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/solr.md
+++ b/docs/platform/guides/database-management/create-database/solr.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-solr
     name: Solr
     parent: database-management-create
-    weight: 120
+    weight: 140
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/solr.md
+++ b/docs/platform/guides/database-management/create-database/solr.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-solr
     name: Solr
     parent: database-management-create
-    weight: 140
+    weight: 290
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/weaviate.md
+++ b/docs/platform/guides/database-management/create-database/weaviate.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-weaviate
     name: Weaviate
     parent: database-management-create
-    weight: 200
+    weight: 210
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/weaviate.md
+++ b/docs/platform/guides/database-management/create-database/weaviate.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-weaviate
     name: Weaviate
     parent: database-management-create
-    weight: 210
+    weight: 300
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/zookeeper.md
+++ b/docs/platform/guides/database-management/create-database/zookeeper.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-zookeeper
     name: ZooKeeper
     parent: database-management-create
-    weight: 270
+    weight: 280
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/database-management/create-database/zookeeper.md
+++ b/docs/platform/guides/database-management/create-database/zookeeper.md
@@ -5,7 +5,7 @@ menu:
     identifier: database-management-create-zookeeper
     name: ZooKeeper
     parent: database-management-create
-    weight: 280
+    weight: 310
 menu_name: docsplatform_{{.version}}
 section_menu_id: guides
 ---

--- a/docs/platform/guides/license-management/overview.md
+++ b/docs/platform/guides/license-management/overview.md
@@ -20,7 +20,7 @@ This guide explores the Billing Console, covering its key components, contract m
 
 ## AppsCode Billing Console <br>
 
-A centralized web-based platform serving as the primary interface for licensing operations in the AppsCode ecosystem. Hosted on [AppsCode Billing Console](https://appsCode.com/billing), this self-managed system allows customers to manage `contracts` by associating clusters, generating `license-proxyserver` installers and tracking clusters for which licenses are generated.
+A centralized web-based platform serving as the primary interface for licensing operations in the AppsCode ecosystem. Hosted on [AppsCode Billing Console](https://appscode.com/billing), this self-managed system allows customers to manage `contracts` by associating clusters, generating `license-proxyserver` installers and tracking clusters for which licenses are generated.
 
 While AppsCode administrators are responsible for the core lifecycle of contracts—including their `creation`, `modification`, `revocation`, and `extension`—customers retain the ability to perform specific operations pertinent to the licensing lifecycle. This includes `associating` and `disassociating` their Kubernetes clusters with allocated contracts, generating `installers` for the `license-proxyserver` through the console, and track the `clusters` for which licenses have been issued.
 
@@ -28,7 +28,7 @@ While AppsCode administrators are responsible for the core lifecycle of contract
 
 ### Key Components
 
-- **Contracts:** Digital agreements, typically established by [AppsCode administrators](https://appsCode.com/contact/) within the Billing Console, that define the terms of AppsCode's product (e.g., KubeDB Platform, KubeDB, KubeStash, KubeVault etc.) usage. This includes the specific AppsCode products which can be licensed, the duration of the contract, applicable features, and the clusters authorized to use these licenses. Contracts ensure that usage aligns with legal and financial terms, providing a foundation for all subsequent actions in the console. Contracts can be configured for either online or offline license validation.
+- **Contracts:** Digital agreements, typically established by [AppsCode administrators](https://appscode.com/contact/) within the Billing Console, that define the terms of AppsCode's product (e.g., KubeDB Platform, KubeDB, KubeStash, KubeVault etc.) usage. This includes the specific AppsCode products which can be licensed, the duration of the contract, applicable features, and the clusters authorized to use these licenses. Contracts ensure that usage aligns with legal and financial terms, providing a foundation for all subsequent actions in the console. Contracts can be configured for either online or offline license validation.
 <br> <br>
 - **Licensed cluster:** The `Licensed Cluster` section within the AppsCode Billing Console offers a comprehensive overview and detailed management capabilities for Kubernetes clusters that have been issued KubeDB Platform product licenses. This component is pivotal for administrators to monitor the cluster(s) `licences` and `events` of licensed products across their infrastructure.
 <br> <br>


### PR DESCRIPTION
Sort the engine lists in `create-database/_index.md` alphabetically within each category, and reassign the per-engine menu `weight` values so the sidebar ordering matches.