### PR TITLE
docs: use /#anchor form for local links instead of .md#anchor

### DIFF
--- a/docs/platform/guides/client-organization/add-cluster-to-existing-client-organization.md
+++ b/docs/platform/guides/client-organization/add-cluster-to-existing-client-organization.md
@@ -45,7 +45,7 @@ Click **Next** to continue.
 
 After selecting the cluster, the wizard continues with the same **Gateway Configuration** and **Telemetry Configuration** steps used when creating a client organization:
 
-- [Gateway Configuration](../create-client-organization.md#step-3-gateway-configuration) — choose a shared or dedicated gateway.
-- [Telemetry Configuration](../create-client-organization.md#step-4-telemetry-configuration) — configure log and metrics retention.
+- [Gateway Configuration](../create-client-organization/#step-3-gateway-configuration) — choose a shared or dedicated gateway.
+- [Telemetry Configuration](../create-client-organization/#step-4-telemetry-configuration) — configure log and metrics retention.
 
 Configure them as needed, then finish to add the cluster to the organization. The new cluster then appears in the **Clusters** section of the organization's details page.

--- a/docs/platform/guides/cluster-management/add-cluster/import-rancher-cluster.md
+++ b/docs/platform/guides/cluster-management/add-cluster/import-rancher-cluster.md
@@ -17,11 +17,11 @@ Importing a `Rancher-Managed` cluster requires a Rancher Type Credential and a R
 
 ## Create Rancher Type Credential
 
-Add a credential of type "Rancher" — see [Credentials Management](../../../account-management/kubernetes/credentials.md#rancher).
+Add a credential of type "Rancher" — see [Credentials Management](../../../account-management/kubernetes/credentials/#rancher).
 
 ## Create a Rancher Managed Organization
 
-Rancher clusters belong to Rancher Managed organizations, not personal accounts. Follow [Create a New Organization](../../../account-management/orgs-members.md#create-a-new-organization) with these settings:
+Rancher clusters belong to Rancher Managed organizations, not personal accounts. Follow [Create a New Organization](../../../account-management/orgs-members/#create-a-new-organization) with these settings:
 
 1. Set the organization's Origin to `Rancher Managed`.
 2. Provide the Rancher `API Endpoint` (found on the `Account & API Keys` page).

--- a/docs/platform/guides/database-management/create-database/cassandra.md
+++ b/docs/platform/guides/database-management/create-database/cassandra.md
@@ -33,8 +33,8 @@ Select the topology under **Database Mode**:
 
 ## Create a Cassandra Database
 
-1. Open the wizard and select **Cassandra** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Cassandra** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/clickhouse.md
+++ b/docs/platform/guides/database-management/create-database/clickhouse.md
@@ -37,8 +37,8 @@ Select the topology under **Database Mode**:
 
 ## Create a ClickHouse Database
 
-1. Open the wizard and select **ClickHouse** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **ClickHouse** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/db2.md
+++ b/docs/platform/guides/database-management/create-database/db2.md
@@ -27,8 +27,8 @@ IBM Db2 is deployed as a single logical instance. Set the **Number of Replicas**
 
 ## Create a IBM Db2 Database
 
-1. Open the wizard and select **IBM Db2** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **IBM Db2** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/documentdb.md
+++ b/docs/platform/guides/database-management/create-database/documentdb.md
@@ -29,8 +29,8 @@ DocumentDB is deployed as a single logical instance. Set the **Number of Replica
 
 ## Create a DocumentDB Database
 
-1. Open the wizard and select **DocumentDB** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **DocumentDB** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/druid.md
+++ b/docs/platform/guides/database-management/create-database/druid.md
@@ -62,8 +62,8 @@ Druid relies on external dependencies for metadata, deep storage, and coordinati
 
 ## Create a Druid Database
 
-1. Open the wizard and select **Druid** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Druid** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/elasticsearch.md
+++ b/docs/platform/guides/database-management/create-database/elasticsearch.md
@@ -45,8 +45,8 @@ Each tier has its own **Number of Replicas**, **Storage size**, **Machine**, **C
 
 ## Create a Elasticsearch Database
 
-1. Open the wizard and select **Elasticsearch** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Elasticsearch** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/hanadb.md
+++ b/docs/platform/guides/database-management/create-database/hanadb.md
@@ -36,8 +36,8 @@ When **SystemReplication** is selected:
 
 ## Create a SAP HANA Database
 
-1. Open the wizard and select **SAP HANA** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **SAP HANA** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/hazelcast.md
+++ b/docs/platform/guides/database-management/create-database/hazelcast.md
@@ -40,8 +40,8 @@ Hazelcast Enterprise features require a license.
 
 ## Create a Hazelcast Database
 
-1. Open the wizard and select **Hazelcast** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Hazelcast** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/ignite.md
+++ b/docs/platform/guides/database-management/create-database/ignite.md
@@ -32,8 +32,8 @@ Select the topology under **Database Mode**. Two modes are available:
 
 ## Create a Ignite Database
 
-1. Open the wizard and select **Ignite** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Ignite** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/kafka.md
+++ b/docs/platform/guides/database-management/create-database/kafka.md
@@ -35,8 +35,8 @@ Each tier has its own **Number of Replicas**, **Storage size**, **Machine**, **C
 
 ## Create a Kafka Database
 
-1. Open the wizard and select **Kafka** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Kafka** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/mariadb.md
+++ b/docs/platform/guides/database-management/create-database/mariadb.md
@@ -32,8 +32,8 @@ Select the topology under **Database Mode**. Two modes are available:
 
 ## Create a MariaDB Database
 
-1. Open the wizard and select **MariaDB** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **MariaDB** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/memcached.md
+++ b/docs/platform/guides/database-management/create-database/memcached.md
@@ -32,8 +32,8 @@ Select the topology under **Database Mode**. Two modes are available:
 
 ## Create a Memcached Database
 
-1. Open the wizard and select **Memcached** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Memcached** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/milvus.md
+++ b/docs/platform/guides/database-management/create-database/milvus.md
@@ -60,8 +60,8 @@ Milvus depends on a metadata store (etcd) and object storage, and exposes a few 
 
 ## Create a Milvus Database
 
-1. Open the wizard and select **Milvus** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Milvus** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/mongodb.md
+++ b/docs/platform/guides/database-management/create-database/mongodb.md
@@ -89,8 +89,8 @@ When **Sharded Cluster** is selected, three subsections appear — **Shard Nodes
 
 ## Create a MongoDB Database
 
-1. Open the wizard and select **MongoDB** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **MongoDB** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/mssqlserver.md
+++ b/docs/platform/guides/database-management/create-database/mssqlserver.md
@@ -47,8 +47,8 @@ When **Topology** mode is used, you may also list the **Databases** to include i
 
 ## Create a Microsoft SQL Server Database
 
-1. Open the wizard and select **Microsoft SQL Server** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Microsoft SQL Server** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/mysql.md
+++ b/docs/platform/guides/database-management/create-database/mysql.md
@@ -38,8 +38,8 @@ Select the topology under **Database Mode**. Available modes:
 
 ## Create a MySQL Database
 
-1. Open the wizard and select **MySQL** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **MySQL** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/neo4j.md
+++ b/docs/platform/guides/database-management/create-database/neo4j.md
@@ -40,8 +40,8 @@ Select the topology under **Database Mode**. Two modes are available:
 
 ## Create a Neo4j Database
 
-1. Open the wizard and select **Neo4j** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Neo4j** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/oracle.md
+++ b/docs/platform/guides/database-management/create-database/oracle.md
@@ -38,8 +38,8 @@ When **DataGuard** is selected:
 
 ## Create a Oracle Database
 
-1. Open the wizard and select **Oracle** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Oracle** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/perconaxtradb.md
+++ b/docs/platform/guides/database-management/create-database/perconaxtradb.md
@@ -29,8 +29,8 @@ Percona XtraDB is deployed as a single logical instance. Set the **Number of Rep
 
 ## Create a Percona XtraDB Database
 
-1. Open the wizard and select **Percona XtraDB** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Percona XtraDB** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/pgbouncer.md
+++ b/docs/platform/guides/database-management/create-database/pgbouncer.md
@@ -42,8 +42,8 @@ PgBouncer pools connections to a backend PostgreSQL database.
 
 ## Create a PgBouncer Database
 
-1. Open the wizard and select **PgBouncer** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **PgBouncer** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/pgpool.md
+++ b/docs/platform/guides/database-management/create-database/pgpool.md
@@ -41,8 +41,8 @@ Pgpool sits in front of a PostgreSQL instance for connection pooling and load ba
 
 ## Create a Pgpool Database
 
-1. Open the wizard and select **Pgpool** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Pgpool** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/postgres.md
+++ b/docs/platform/guides/database-management/create-database/postgres.md
@@ -37,8 +37,8 @@ When **Cluster** is selected, configure replication behaviour:
 
 ## Create a PostgreSQL Database
 
-1. Open the wizard and select **PostgreSQL** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **PostgreSQL** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/proxysql.md
+++ b/docs/platform/guides/database-management/create-database/proxysql.md
@@ -41,8 +41,8 @@ ProxySQL proxies traffic to a backend MySQL-family cluster.
 
 ## Create a ProxySQL Database
 
-1. Open the wizard and select **ProxySQL** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **ProxySQL** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/qdrant.md
+++ b/docs/platform/guides/database-management/create-database/qdrant.md
@@ -41,8 +41,8 @@ Select the topology under **Database Mode**:
 
 ## Create a Qdrant Database
 
-1. Open the wizard and select **Qdrant** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Qdrant** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/rabbitmq.md
+++ b/docs/platform/guides/database-management/create-database/rabbitmq.md
@@ -32,8 +32,8 @@ Select the topology under **Database Mode**. Two modes are available:
 
 ## Create a RabbitMQ Database
 
-1. Open the wizard and select **RabbitMQ** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **RabbitMQ** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/redis.md
+++ b/docs/platform/guides/database-management/create-database/redis.md
@@ -34,7 +34,7 @@ Select the topology under **Database Mode**. Three modes are available:
 
 ## Announce Redis Endpoints (Cluster Mode Only)
 
-> **Important — required if you plan to expose a Cluster-mode Redis externally.** The default external endpoint (via **Expose via Gateway**, see [Additional Options](../common-steps.md#6-additional-options)) is a single Kubernetes Service that load-balances across *all* pods in *all* shards. Redis Cluster clients don't work well with that: a client's request is only served correctly if the pod it happens to connect to owns the requested key's slot — otherwise Redis replies with a redirect to the internal pod IP, which the external client cannot reach and the connection times out.
+> **Important — required if you plan to expose a Cluster-mode Redis externally.** The default external endpoint (via **Expose via Gateway**, see [Additional Options](../common-steps/#6-additional-options)) is a single Kubernetes Service that load-balances across *all* pods in *all* shards. Redis Cluster clients don't work well with that: a client's request is only served correctly if the pod it happens to connect to owns the requested key's slot — otherwise Redis replies with a redirect to the internal pod IP, which the external client cannot reach and the connection times out.
 >
 > Toggling on **Announce Redis Endpoints** tells each Redis node to advertise its externally reachable address instead of its internal IP, so redirects point somewhere the client can actually connect to.
 
@@ -57,8 +57,8 @@ For the underlying mechanism, see the [Redis External Connections guide](https:/
 
 ## Create a Redis Database
 
-1. Open the wizard and select **Redis** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database). For **Cluster** mode, configure [Announce Redis Endpoints](#announce-redis-endpoints-cluster-mode-only) if you'll expose it externally.
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Redis** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database). For **Cluster** mode, configure [Announce Redis Endpoints](#announce-redis-endpoints-cluster-mode-only) if you'll expose it externally.
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/singlestore.md
+++ b/docs/platform/guides/database-management/create-database/singlestore.md
@@ -50,8 +50,8 @@ SingleStore is commercial software and requires a license.
 
 ## Create a SingleStore Database
 
-1. Open the wizard and select **SingleStore** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **SingleStore** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/solr.md
+++ b/docs/platform/guides/database-management/create-database/solr.md
@@ -48,8 +48,8 @@ SolrCloud requires ZooKeeper for coordination.
 
 ## Create a Solr Database
 
-1. Open the wizard and select **Solr** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Solr** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/weaviate.md
+++ b/docs/platform/guides/database-management/create-database/weaviate.md
@@ -38,8 +38,8 @@ Weaviate is deployed as a single logical instance. Set the **Number of Replicas*
 
 ## Create a Weaviate Database
 
-1. Open the wizard and select **Weaviate** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **Weaviate** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/guides/database-management/create-database/zookeeper.md
+++ b/docs/platform/guides/database-management/create-database/zookeeper.md
@@ -32,8 +32,8 @@ Select the topology under **Database Mode**. Two modes are available:
 
 ## Create a ZooKeeper Database
 
-1. Open the wizard and select **ZooKeeper** — see [Getting Started](../common-steps.md#1-getting-started) and [Select a Database Type](../common-steps.md#2-select-a-database-type).
-1. Set the [namespace and name](../common-steps.md#3-choose-namespace-and-name).
-1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps.md#4-configure-the-database).
-1. Optionally configure [Advanced Configuration](../common-steps.md#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps.md#6-additional-options) (monitoring, backup, TLS, gateway).
-1. Click [**Deploy**](../common-steps.md#7-deploy).
+1. Open the wizard and select **ZooKeeper** — see [Getting Started](../common-steps/#1-getting-started) and [Select a Database Type](../common-steps/#2-select-a-database-type).
+1. Set the [namespace and name](../common-steps/#3-choose-namespace-and-name).
+1. Pick the database version and the **Database Mode** described above, then set the machine profile and storage — see [Configure the Database](../common-steps/#4-configure-the-database).
+1. Optionally configure [Advanced Configuration](../common-steps/#5-advanced-configuration) (labels, deletion policy, credentials, point-in-time recovery) and [Additional Options](../common-steps/#6-additional-options) (monitoring, backup, TLS, gateway).
+1. Click [**Deploy**](../common-steps/#7-deploy).

--- a/docs/platform/selfhost-setup/install/aws-marketplace.md
+++ b/docs/platform/selfhost-setup/install/aws-marketplace.md
@@ -18,7 +18,7 @@ To install **KubeDB Platform**, you need to have the permissions to manage **EC2
 
 ### Prerequisite
 
-See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
+See [Prerequisites](../common-config/#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
 
 You have to create an `Access Key` and `Secret Key` with following policies attached. Check out similar [eksctl docs](https://eksctl.io/usage/minimum-iam-policies/) for reference. 
 
@@ -263,11 +263,11 @@ These credentials define the primary super-user and the initial organizational s
 For openshift cluster toggle Red Hat OpenShift cluster and give Kube API Server endpoint 
 
 ### 4. Registry
-See [Registry](../common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
+See [Registry](../common-config/#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
 
 ### 5. Monitoring
 
-See [Monitoring](../common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
+See [Monitoring](../common-config/#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
 
 
 ### 6. Settings
@@ -282,7 +282,7 @@ In this section you can enable or disable features. You can also create an initi
 
 
 ### 8. Branding & UI Customization
-See [Branding & UI Customization](../common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
+See [Branding & UI Customization](../common-config/#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
 
 ### 9. Generate Installer and Documentation
 

--- a/docs/platform/selfhost-setup/install/azure-marketplace.md
+++ b/docs/platform/selfhost-setup/install/azure-marketplace.md
@@ -16,7 +16,7 @@ Welcome to the KubeDB Platform's **Azure Marketplace** deployment! This guide wi
 
 ### Prerequisites
 
-See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
+See [Prerequisites](../common-config/#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
 
 ## Getting Started
 
@@ -66,17 +66,17 @@ Put **Subscription ID**, **Tenant ID**, **Client ID** and **Client Secret** in t
 
 ### 4. Global Administrative Settings
 
-See [Global Administrative Settings](../common-config.md#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
+See [Global Administrative Settings](../common-config/#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
 
 For openshift cluster toggle Red Hat OpenShift cluster and give Kube API Server endpoint 
 
 ### 5. Registry
 
-See [Registry](../common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
+See [Registry](../common-config/#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
 
 ### 6. Monitoring
 
-See [Monitoring](../common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
+See [Monitoring](../common-config/#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
 
 ### 7. Settings
 
@@ -94,7 +94,7 @@ In this section you can enable or disable features.  You can also create an init
 
 ### 9. Branding & UI Customization
 
-See [Branding & UI Customization](../common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
+See [Branding & UI Customization](../common-config/#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
 
 ### 10. Generate Installer and Documentation
 

--- a/docs/platform/selfhost-setup/install/cloud-demo.md
+++ b/docs/platform/selfhost-setup/install/cloud-demo.md
@@ -16,7 +16,7 @@ Welcome to the KubeDB Platform's "Cloud Demo" deployment! Follow these steps to 
 
 ### Prerequisites
 
-See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note. 
+See [Prerequisites](../common-config/#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note. 
 
 ### 1. Visit the KubeDB Platform Self-Hosted Page
 
@@ -38,34 +38,34 @@ Before beginning the installation, identify your target infrastructure and clust
 
 #### Additional configuration for EKS cluster
 
-See [Additional configuration for EKS cluster](../common-config.md#additional-configuration-for-eks-cluster) in the Common Configuration guide for the EBS CSI / AWS Load Balancer Controller prerequisites and the commands to fetch the Kube API server endpoint, subnet IDs, and EIP allocation IDs.
+See [Additional configuration for EKS cluster](../common-config/#additional-configuration-for-eks-cluster) in the Common Configuration guide for the EBS CSI / AWS Load Balancer Controller prerequisites and the commands to fetch the Kube API server endpoint, subnet IDs, and EIP allocation IDs.
 
 ### 3. Global Administrative Settings
-See [Global Administrative Settings](../common-config.md#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
+See [Global Administrative Settings](../common-config/#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
 
 ### 4. Registry
-See [Registry](../common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
+See [Registry](../common-config/#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
 
 ### 5. Monitoring
 
-See [Monitoring](../common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
+See [Monitoring](../common-config/#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
 
 
 ### 6. Settings
 
 #### Domain White List and Proxy Servers
 
-See [Domain White List and Proxy Servers](../common-config.md#domain-white-list-and-proxy-servers) in the Common Configuration guide for whitelisting domains, proxy servers, and login/logout URLs.
+See [Domain White List and Proxy Servers](../common-config/#domain-white-list-and-proxy-servers) in the Common Configuration guide for whitelisting domains, proxy servers, and login/logout URLs.
 
 ### 7. Ingress & Gateway
 
-See [Ingress & Gateway](../common-config.md#ingress--gateway) in the Common Configuration guide for exposing the platform via the Gateway API or standard Ingress.
+See [Ingress & Gateway](../common-config/#ingress--gateway) in the Common Configuration guide for exposing the platform via the Gateway API or standard Ingress.
 
 ### 8. Self Management
-See [Self Management](../common-config.md#self-management) in the Common Configuration guide to enable or disable platform features.
+See [Self Management](../common-config/#self-management) in the Common Configuration guide to enable or disable platform features.
 
 ### 9. Branding & UI Customization
-See [Branding & UI Customization](../common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
+See [Branding & UI Customization](../common-config/#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
 
 ### 10. Generate Installer and Documentation
 

--- a/docs/platform/selfhost-setup/install/offline.md
+++ b/docs/platform/selfhost-setup/install/offline.md
@@ -18,7 +18,7 @@ In offline mode, AppsCode never receives any of your KubeDB usage data. AppsCode
 
 ### Prerequisites
 
-See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
+See [Prerequisites](../common-config/#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
 
 ### 1. Visit the KubeDB Platform Self-Hosted Page
 

--- a/docs/platform/selfhost-setup/install/onprem-demo.md
+++ b/docs/platform/selfhost-setup/install/onprem-demo.md
@@ -16,7 +16,7 @@ Welcome to the KubeDB Platform's "Onprem Demo" deployment! Follow these steps to
 
 ### Prerequisites
 
-See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note. 
+See [Prerequisites](../common-config/#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note. 
 
 ### 1. Visit the KubeDB Platform Self-Hosted Page
 
@@ -37,38 +37,38 @@ Before beginning the installation, identify your target infrastructure and clust
 > For Red Hat OpenShift clusters, see the [Deploying KubeDB Platform in OpenShift Cluster](../openshift-cluster.md) guide.
 
 ### 3. Global Administrative Settings
-See [Global Administrative Settings](../common-config.md#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
+See [Global Administrative Settings](../common-config/#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
 
 ### 4. Registry
-See [Registry](../common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
+See [Registry](../common-config/#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
 
 ### 5. Monitoring
 
-See [Monitoring](../common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
+See [Monitoring](../common-config/#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
 
 
 ### 6. Settings
 
 #### Domain White List and Proxy Servers
 
-See [Domain White List and Proxy Servers](../common-config.md#domain-white-list-and-proxy-servers) in the Common Configuration guide for whitelisting domains, proxy servers, and login/logout URLs.
+See [Domain White List and Proxy Servers](../common-config/#domain-white-list-and-proxy-servers) in the Common Configuration guide for whitelisting domains, proxy servers, and login/logout URLs.
 
 ### 7. TLS
-See [TLS](../common-config.md#tls) in the Common Configuration guide for configuring the certificate issuer (External or CA).
+See [TLS](../common-config/#tls) in the Common Configuration guide for configuring the certificate issuer (External or CA).
 
 ### 8. Ingress & Gateway
 
-See [Ingress & Gateway](../common-config.md#ingress--gateway) in the Common Configuration guide for exposing the platform via the Gateway API or standard Ingress.
+See [Ingress & Gateway](../common-config/#ingress--gateway) in the Common Configuration guide for exposing the platform via the Gateway API or standard Ingress.
 
 ### 9. NATS
 
-See [NATS](../common-config.md#nats) in the Common Configuration guide for configuring the internal messaging system (expose method, replicas, and resources).
+See [NATS](../common-config/#nats) in the Common Configuration guide for configuring the internal messaging system (expose method, replicas, and resources).
 
 ### 10. Self Management
-See [Self Management](../common-config.md#self-management) in the Common Configuration guide to enable or disable platform features.
+See [Self Management](../common-config/#self-management) in the Common Configuration guide to enable or disable platform features.
 
 ### 11. Branding & UI Customization
-See [Branding & UI Customization](../common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
+See [Branding & UI Customization](../common-config/#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
 
 ### 12. Generate Installer and Documentation
 

--- a/docs/platform/selfhost-setup/install/openshift-cluster.md
+++ b/docs/platform/selfhost-setup/install/openshift-cluster.md
@@ -21,7 +21,7 @@ Regardless of the mode, an OpenShift deployment always requires you to toggle th
 
 ### Prerequisites
 
-See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
+See [Prerequisites](../common-config/#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note.
 
 ### 1. Visit the KubeDB Platform Self-Hosted Page
 

--- a/docs/platform/selfhost-setup/install/selfhosted-production.md
+++ b/docs/platform/selfhost-setup/install/selfhosted-production.md
@@ -30,7 +30,7 @@ This guide provides a structured approach to deploying the platform manually. We
 
 > **Note:** Ensure your infrastructure meets the minimum system requirements before proceeding to the configuration steps.
 
-See [Prerequisites](../common-config.md#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note. 
+See [Prerequisites](../common-config/#prerequisites) in the Common Configuration guide for the minimum cluster requirements and the optional k3s setup note. 
 
 
 ### 1. Visit the KubeDB Platform Self-Hosted Page
@@ -55,7 +55,7 @@ Before beginning the installation, identify your target infrastructure and clust
 
 ### Additional configuration for EKS cluster
 
-See [Additional configuration for EKS cluster](../common-config.md#additional-configuration-for-eks-cluster) in the Common Configuration guide for the EBS CSI / AWS Load Balancer Controller prerequisites and the commands to fetch the Kube API server endpoint, subnet IDs, and EIP allocation IDs.
+See [Additional configuration for EKS cluster](../common-config/#additional-configuration-for-eks-cluster) in the Common Configuration guide for the EBS CSI / AWS Load Balancer Controller prerequisites and the commands to fetch the Kube API server endpoint, subnet IDs, and EIP allocation IDs.
 
 ### Configuring AWS credentialless mode
 
@@ -169,7 +169,7 @@ aws eks associate-access-policy \
 Provide the output role arn as Ace Installer Role ARN `echo $ROLE_ARN`in the **Ace Installer Role ARN** field. 
 
 ### 3. Global Administrative Settings
-See [Global Administrative Settings](../common-config.md#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
+See [Global Administrative Settings](../common-config/#global-administrative-settings) in the Common Configuration guide for the System Admin account fields (display name, email, password, and initial organization).
 
 ### 4. Release
 Define the specific Kubernetes namespace and release information for the KubeDB Platform components.
@@ -179,7 +179,7 @@ Define the specific Kubernetes namespace and release information for the KubeDB 
 * **Namespace Automation:** Toggle **"Create namespaces during Helm install"** if you want the installer to handle namespace lifecycle management.
 
 ### 5. Registry
-See [Registry](../common-config.md#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
+See [Registry](../common-config/#registry) in the Common Configuration guide for Docker registry proxies, Helm repositories, credentials, certs, and image pull secrets.
 
 ### 6. Settings
 This secton is for Persistence & Resource Allocation. Properly sizing your resources is critical for production stability. Configure CPU Requests, CPU Limits, Memory Request and  Memory Limit for both cache and Database
@@ -193,7 +193,7 @@ This secton is for Persistence & Resource Allocation. Properly sizing your resou
 
 #### Domain White List and Proxy Servers
 
-See [Domain White List and Proxy Servers](../common-config.md#domain-white-list-and-proxy-servers) in the Common Configuration guide for whitelisting domains, proxy servers, and login/logout URLs.
+See [Domain White List and Proxy Servers](../common-config/#domain-white-list-and-proxy-servers) in the Common Configuration guide for whitelisting domains, proxy servers, and login/logout URLs.
 
 
 #### KubeStash
@@ -205,7 +205,7 @@ KubeDB Platform uses **KubeStash** for automated backups and disaster recovery.
 
 ### 7. Monitoring
 
-See [Monitoring](../common-config.md#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
+See [Monitoring](../common-config/#monitoring) in the Common Configuration guide for Alertmanager email and webhook configuration.
 
 ### 8. Infra 
 
@@ -224,17 +224,17 @@ See [Monitoring](../common-config.md#monitoring) in the Common Configuration gui
   * **letsencrypt-staging:** Use this for testing your installation
 
 ### 9. Ingress & Gateway
-See [Ingress & Gateway](../common-config.md#ingress--gateway) in the Common Configuration guide for exposing the platform via the Gateway API or standard Ingress.
+See [Ingress & Gateway](../common-config/#ingress--gateway) in the Common Configuration guide for exposing the platform via the Gateway API or standard Ingress.
 
 ### 10. NATS
 
-See [NATS](../common-config.md#nats) in the Common Configuration guide for configuring the internal messaging system (expose method, replicas, and resources).
+See [NATS](../common-config/#nats) in the Common Configuration guide for configuring the internal messaging system (expose method, replicas, and resources).
 
 ### 11. Self Management
-See [Self Management](../common-config.md#self-management) in the Common Configuration guide to enable or disable platform features.
+See [Self Management](../common-config/#self-management) in the Common Configuration guide to enable or disable platform features.
 
 ### 12. Branding & UI Customization
-See [Branding & UI Customization](../common-config.md#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
+See [Branding & UI Customization](../common-config/#branding--ui-customization) in the Common Configuration guide to re-brand the platform interface.
 
 ### 13. Generate Installer and Documentation
 


### PR DESCRIPTION
Convert all local doc anchor links from the `file.md#anchor` form to the `file/#anchor` form (255 links across 39 files), which resolves correctly on the rendered site.