### PR TITLE
Prepare for release v2026.7.10

### DIFF
--- a/docs/platform/CHANGELOG-v2026.7.10.md
+++ b/docs/platform/CHANGELOG-v2026.7.10.md
@@ -1,0 +1,118 @@
+---
+title: Changelog | ACE
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-ace-v2026.7.10
+    name: Changelog-v2026.7.10
+    parent: welcome
+    weight: 20260710
+product_name: ace
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.7.10/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.7.10/
+---
+
+# ACE v2026.7.10 (2026-07-13)
+
+
+## [appscode-cloud/b3](https://github.com/appscode-cloud/b3)
+
+### [v2026.7.10](https://github.com/appscode-cloud/b3/releases/tag/v2026.7.10)
+
+- [f90ecc7e](https://github.com/appscode-cloud/b3/commit/f90ecc7e0d) Prepare for release v2026.7.10 (#1560)
+- [e766b5a7](https://github.com/appscode-cloud/b3/commit/e766b5a7d1) Modernize golangci-lint config, clean up all lint findings, and enable lint in CI (#1559)
+- [6c3d23d0](https://github.com/appscode-cloud/b3/commit/6c3d23d0db) Preallocate slices and close healthz response body (#1558)
+
+
+
+## [appscode-cloud/installer](https://github.com/appscode-cloud/installer)
+
+### [v2026.7.10](https://github.com/appscode-cloud/installer/releases/tag/v2026.7.10)
+
+- [ec739356](https://github.com/appscode-cloud/installer/commit/ec739356) Prepare for release v2026.7.10 (#1300)
+- [95567425](https://github.com/appscode-cloud/installer/commit/95567425) Add reproducible make targets for catalog and certified charts (#1301)
+- [46a85a85](https://github.com/appscode-cloud/installer/commit/46a85a85) Propagate chart version to regcache dependency in ace-installer (#1299)
+- [8028dd4a](https://github.com/appscode-cloud/installer/commit/8028dd4a) Modernize golangci-lint config (#1298)
+
+
+
+## [appscode-cloud/ui-wizards](https://github.com/appscode-cloud/ui-wizards)
+
+### [v0.36.0](https://github.com/appscode-cloud/ui-wizards/releases/tag/v0.36.0)
+
+- [e2b93a81](https://github.com/appscode-cloud/ui-wizards/commit/e2b93a81b) Prepare for release v0.36.0 (#1083)
+- [ca807994](https://github.com/appscode-cloud/ui-wizards/commit/ca807994c) Modernize golangci-lint config (#1082)
+- [ffa9ab38](https://github.com/appscode-cloud/ui-wizards/commit/ffa9ab383) fix resource init and validation in vertical scaling ops (#1081)
+- [5a1452d4](https://github.com/appscode-cloud/ui-wizards/commit/5a1452d44) Set storage-metrics-server chart version to v0.1.0
+- [a8a7507c](https://github.com/appscode-cloud/ui-wizards/commit/a8a7507c3) Generate editors (#1080)
+- [e44adf55](https://github.com/appscode-cloud/ui-wizards/commit/e44adf553) fix mongodb horizons conditions (#1079)
+- [82ad918d](https://github.com/appscode-cloud/ui-wizards/commit/82ad918d4) Remove ferretdb
+
+
+
+## [appscode/website](https://github.com/appscode/website)
+
+### [v2026.7.10](https://github.com/appscode/website/releases/tag/v2026.7.10)
+
+- [0b246ffe](https://github.com/appscode/website/commit/0b246ffe) Prepare for release v2026.7.10 (#217)
+
+
+
+## [kmodules/image-packer](https://github.com/kmodules/image-packer)
+
+### [v2026.7.10](https://github.com/kmodules/image-packer/releases/tag/v2026.7.10)
+
+- [18b029a2](https://github.com/kmodules/image-packer/commit/18b029a2) Prepare for release v2026.7.10 (#59)
+- [a8bd9927](https://github.com/kmodules/image-packer/commit/a8bd9927) Expand ${...} image tags using availableVersions (#58)
+- [ec36f527](https://github.com/kmodules/image-packer/commit/ec36f527) Modernize golangci-lint config (#57)
+- [ed3c452e](https://github.com/kmodules/image-packer/commit/ed3c452e) Pass ci/ci-values.yaml to helm template when present (#56)
+
+
+
+## [kmodules/resource-metadata](https://github.com/kmodules/resource-metadata)
+
+### [v0.48.0](https://github.com/kmodules/resource-metadata/releases/tag/v0.48.0)
+
+- [ae8fcd22](https://github.com/kmodules/resource-metadata/commit/ae8fcd22e) Prepare for release v0.48.0 (#658)
+- [f060724a](https://github.com/kmodules/resource-metadata/commit/f060724a6) KubeDB / KubeStash v2026.7.10
+- [cae64e5b](https://github.com/kmodules/resource-metadata/commit/cae64e5bc) Modernize golangci-lint config (#657)
+- [57e63940](https://github.com/kmodules/resource-metadata/commit/57e639408) Sync catalog bindings
+- [b5c0d799](https://github.com/kmodules/resource-metadata/commit/b5c0d799a) Update for datastore & ops
+- [9e2d67a3](https://github.com/kmodules/resource-metadata/commit/9e2d67a3f) Sync digests
+- [4e9dbd2f](https://github.com/kmodules/resource-metadata/commit/4e9dbd2f9) Grafana Dashboards -> Dashboards
+
+
+
+## [kubeops/installer](https://github.com/kubeops/installer)
+
+### [v2026.7.10](https://github.com/kubeops/installer/releases/tag/v2026.7.10)
+
+- [29761e3b](https://github.com/kubeops/installer/commit/29761e3b) Prepare for release v2026.7.10 (#505)
+- [3d2d92b0](https://github.com/kubeops/installer/commit/3d2d92b0) Modernize golangci-lint config (#504)
+- [53f65b9d](https://github.com/kubeops/installer/commit/53f65b9d) [Update SideKick ClusterRole] Add Snapshot, ServiceExport Permission (#489)
+
+
+
+## [kubeops/ui-server](https://github.com/kubeops/ui-server)
+
+### [v0.6.0](https://github.com/kubeops/ui-server/releases/tag/v0.6.0)
+
+- [57fdaa2c](https://github.com/kubeops/ui-server/commit/57fdaa2c7) Prepare for release v0.6.0 (#436)
+- [10ce260b](https://github.com/kubeops/ui-server/commit/10ce260b2) Modernize golangci-lint config and switch formatter to gofumpt (#435)
+
+
+
+## [kubepack/lib-app](https://github.com/kubepack/lib-app)
+
+### [v0.24.0](https://github.com/kubepack/lib-app/releases/tag/v0.24.0)
+
+- [7d7088f3](https://github.com/kubepack/lib-app/commit/7d7088f35) Prepare for release v0.24.0 (#179)
+- [dd9de1cc](https://github.com/kubepack/lib-app/commit/dd9de1ccd) Sync catalog bindings; Remove ferretbinding
+- [2e3a6163](https://github.com/kubepack/lib-app/commit/2e3a61639) fusion: keep full HelmRelease object in values.yaml (#177)
+
+
+
+


### PR DESCRIPTION
ProductLine: ACE
Release: v2026.7.10
Release-tracker: https://github.com/appscode-cloud/CHANGELOG/pull/76
Signed-off-by: 1gtm <1gtm@appscode.com>