### PR TITLE
docs(platform): fix section-overview links (README → overview.md)

### DIFF
--- a/docs/platform/api/README.md
+++ b/docs/platform/api/README.md
@@ -104,24 +104,24 @@ The v1 API surface is organized into the following logical groups:
 
 | # | Group | Base path(s) | What it covers | Availability |
 |---|-------|--------------|----------------|--------------|
-| 1 | [Identity: Users & Settings](../api/users-settings/) | `/api/v1/user`, `/api/v1/users` | Accounts, profile/security settings, tokens, credentials | always |
-| 2 | [Identity: Organizations & Teams](../api/organizations-teams/) | `/api/v1/orgs`, `/api/v1/teams` | Orgs, members, teams, org tokens | always |
-| 3 | [Administration](../api/administration/) | `/api/v1/admin`, `/api/v1/accounts/admin` | Admin console, site settings | always |
-| 4 | [Authorization (Roles & Permissions)](../api/authorization/) | `/api/v1/authz` | Custom roles & permissions | always |
-| 5 | [Cluster Management (v1 + K8s proxy + Helm)](../api/cluster-management-v1/) | `/api/v1/clusters` | Cluster lifecycle, Kubernetes proxy, Helm | always |
-| 6 | [Cluster Management v2](../api/cluster-management-v2/) | `/api/v1/clustersv2` | Hub-aware cluster API, subscriptions, gateways | always |
-| 7 | [Multi-cluster (OCM hub/spoke)](../api/multicluster-ocm/) | `/api/v1/clusters/:owner/:cluster/...` | Hub/spoke, cluster sets, feature sets | always |
-| 8 | [Client Organizations](../api/client-organizations/) | `/api/v1/user/client*`, `/api/v1/clusters/.../permission` | Managed-service client orgs | always |
-| 9 | [Cloud Providers](../api/cloud-providers/) | `/api/v1/clouds` | Provider discovery for provisioning | always |
-| 10 | [Platform Installer](../api/ace-installer/) | `/api/v1/ace-installer` | Self-host installer bundles | AppsCode-hosted only |
-| 11 | [Platform Upgrade](../api/ace-upgrade/) | `/api/v1/upgrade`, `/api/v1/clusters/.../upgrade` | Platform & cluster upgrades | always |
-| 12 | [Licensing & Contracts](../api/licensing-contracts/) | `/api/v1/contracts`, `/api/v1/user/contracts`, `/api/v1/register`, `/api/v1/license` | Contracts, licenses, registration | contracts: AppsCode-hosted |
-| 13 | [Billing Dashboard & Usage Reports](../api/billing-dashboard/) | `/api/v1/dashboard`, `/api/v1/user/dashboard`, `/api/v1/dbaas` | Usage reports & billing dashboards | billing-enabled deployments |
-| 14 | [Marketplace](../api/marketplace/) | `/api/v1/marketplaces` (separate service), `/api/v1/proxy/metered-billing` | Cloud-marketplace webhooks & metering | marketplace deployments |
-| 15 | [Monitoring & Telemetry](../api/monitoring-telemetry/) | `/api/v1/telemetry`, `/api/v1/trickster` | Telemetry stack, Trickster auth proxy | always |
-| 16 | [Rancher Integration](../api/rancher/) | `/api/v1/rancher` | Rancher sync & proxy | always |
-| 17 | [Helm Chart Repositories (public)](../api/chart-repositories/) | `/api/v1/chartrepositories` | Public Helm chart repositories | always |
-| 18 | [Miscellaneous & Site Settings](../api/miscellaneous/) | `/api/v1/version`, `/api/v1/markdown`, `/api/v1/branding`, ... | Version, markdown, health | always |
+| 1 | [Identity: Users & Settings](../api/users-settings/overview/) | `/api/v1/user`, `/api/v1/users` | Accounts, profile/security settings, tokens, credentials | always |
+| 2 | [Identity: Organizations & Teams](../api/organizations-teams/overview/) | `/api/v1/orgs`, `/api/v1/teams` | Orgs, members, teams, org tokens | always |
+| 3 | [Administration](../api/administration/overview/) | `/api/v1/admin`, `/api/v1/accounts/admin` | Admin console, site settings | always |
+| 4 | [Authorization (Roles & Permissions)](../api/authorization/overview/) | `/api/v1/authz` | Custom roles & permissions | always |
+| 5 | [Cluster Management (v1 + K8s proxy + Helm)](../api/cluster-management-v1/overview/) | `/api/v1/clusters` | Cluster lifecycle, Kubernetes proxy, Helm | always |
+| 6 | [Cluster Management v2](../api/cluster-management-v2/overview/) | `/api/v1/clustersv2` | Hub-aware cluster API, subscriptions, gateways | always |
+| 7 | [Multi-cluster (OCM hub/spoke)](../api/multicluster-ocm/overview/) | `/api/v1/clusters/:owner/:cluster/...` | Hub/spoke, cluster sets, feature sets | always |
+| 8 | [Client Organizations](../api/client-organizations/overview/) | `/api/v1/user/client*`, `/api/v1/clusters/.../permission` | Managed-service client orgs | always |
+| 9 | [Cloud Providers](../api/cloud-providers/overview/) | `/api/v1/clouds` | Provider discovery for provisioning | always |
+| 10 | [Platform Installer](../api/ace-installer/overview/) | `/api/v1/ace-installer` | Self-host installer bundles | AppsCode-hosted only |
+| 11 | [Platform Upgrade](../api/ace-upgrade/overview/) | `/api/v1/upgrade`, `/api/v1/clusters/.../upgrade` | Platform & cluster upgrades | always |
+| 12 | [Licensing & Contracts](../api/licensing-contracts/overview/) | `/api/v1/contracts`, `/api/v1/user/contracts`, `/api/v1/register`, `/api/v1/license` | Contracts, licenses, registration | contracts: AppsCode-hosted |
+| 13 | [Billing Dashboard & Usage Reports](../api/billing-dashboard/overview/) | `/api/v1/dashboard`, `/api/v1/user/dashboard`, `/api/v1/dbaas` | Usage reports & billing dashboards | billing-enabled deployments |
+| 14 | [Marketplace](../api/marketplace/overview/) | `/api/v1/marketplaces` (separate service), `/api/v1/proxy/metered-billing` | Cloud-marketplace webhooks & metering | marketplace deployments |
+| 15 | [Monitoring & Telemetry](../api/monitoring-telemetry/overview/) | `/api/v1/telemetry`, `/api/v1/trickster` | Telemetry stack, Trickster auth proxy | always |
+| 16 | [Rancher Integration](../api/rancher/overview/) | `/api/v1/rancher` | Rancher sync & proxy | always |
+| 17 | [Helm Chart Repositories (public)](../api/chart-repositories/overview/) | `/api/v1/chartrepositories` | Public Helm chart repositories | always |
+| 18 | [Miscellaneous & Site Settings](../api/miscellaneous/overview/) | `/api/v1/version`, `/api/v1/markdown`, `/api/v1/branding`, ... | Version, markdown, health | always |
 
 ![KubeDB Platform /api/v1 API group map](../api/images/api-groups.svg)
 

--- a/docs/platform/api/ace-installer/overview.md
+++ b/docs/platform/api/ace-installer/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-ace-installer-readme
+    identifier: api-ace-installer-overview
     name: Overview
     parent: api-ace-installer
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/ace-installer/
-aliases:
-- /docs/platform/{{.version}}/api/ace-installer/overview/
 ---
 
 # Platform Installer API

--- a/docs/platform/api/ace-installer/overview.md
+++ b/docs/platform/api/ace-installer/overview.md
@@ -45,6 +45,6 @@ Generates and manages self-host installer bundles. Token + org context; per-acti
 
 ## Pages
 
-- [Platform Installer](../ace-installer.md) — schema/model, generate/import,
+- [Platform Installer](../ace-installer) — schema/model, generate/import,
   installer metadata and latest version, installers CRUD, reconfigure/upgrade,
   versions/archives, and marketplace installer status.

--- a/docs/platform/api/ace-upgrade/overview.md
+++ b/docs/platform/api/ace-upgrade/overview.md
@@ -45,11 +45,11 @@ Platform and per-cluster upgrades (FluxCD-driven).
 
 ## Pages
 
-- [Platform Upgrade](../platform-upgrade.md) — the
+- [Platform Upgrade](../platform-upgrade) — the
   `/api/v1/upgrade*` endpoints: platform upgrade status, job status, history, and
   current version, plus triggering a platform upgrade. Requires site-admin org
   authorization.
-- [Cluster Upgrade](../cluster-upgrade.md) — the
+- [Cluster Upgrade](../cluster-upgrade) — the
   `/api/v1/clusters/{owner}/{cluster}/upgrade*` and `.../spoke/upgrade*`
   endpoints: imported-cluster and spoke-cluster upgrade status, history, current
   and latest versions, plus triggering cluster/spoke upgrades. Gated by cluster

--- a/docs/platform/api/ace-upgrade/overview.md
+++ b/docs/platform/api/ace-upgrade/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-ace-upgrade-readme
+    identifier: api-ace-upgrade-overview
     name: Overview
     parent: api-ace-upgrade
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/ace-upgrade/
-aliases:
-- /docs/platform/{{.version}}/api/ace-upgrade/overview/
 ---
 
 # Platform Upgrade

--- a/docs/platform/api/administration/overview.md
+++ b/docs/platform/api/administration/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-administration-readme
+    identifier: api-administration-overview
     name: Overview
     parent: api-administration
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/administration/
-aliases:
-- /docs/platform/{{.version}}/api/administration/overview/
 ---
 
 # Administration

--- a/docs/platform/api/administration/overview.md
+++ b/docs/platform/api/administration/overview.md
@@ -82,6 +82,6 @@ Two admin surfaces: the legacy `/admin` group (administrative-org admins) and `/
 
 ## Pages
 
-- [Administrative-Org Admin](../admin-org.md) — `/api/v1/admin/*`: manage users and their organizations.
-- [Site Admin Console](../site-admin-console.md) — `/api/v1/accounts/admin/*`: dashboard, users, orgs, clusters, auth sources.
-- [Site Settings](../site-settings.md) — `/allowed-domains`, `/disable-registration`, `/branding`.
+- [Administrative-Org Admin](../admin-org) — `/api/v1/admin/*`: manage users and their organizations.
+- [Site Admin Console](../site-admin-console) — `/api/v1/accounts/admin/*`: dashboard, users, orgs, clusters, auth sources.
+- [Site Settings](../site-settings) — `/allowed-domains`, `/disable-registration`, `/branding`.

--- a/docs/platform/api/authorization/overview.md
+++ b/docs/platform/api/authorization/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-authorization-readme
+    identifier: api-authorization-overview
     name: Overview
     parent: api-authorization
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/authorization/
-aliases:
-- /docs/platform/{{.version}}/api/authorization/overview/
 ---
 
 # Authorization

--- a/docs/platform/api/authorization/overview.md
+++ b/docs/platform/api/authorization/overview.md
@@ -37,6 +37,6 @@ Custom role management backed by the relationship-based authorization model.
 
 ## Pages
 
-- [Roles & Permissions](../roles-permissions.md) — object
+- [Roles & Permissions](../roles-permissions) — object
   allowed-permissions lookups (single and batch), the available-permissions
   catalog, role CRUD, and role principal listings.

--- a/docs/platform/api/billing-dashboard/overview.md
+++ b/docs/platform/api/billing-dashboard/overview.md
@@ -83,13 +83,13 @@ Available on billing-enabled deployments.
 
 ## Pages
 
-- [Admin Billing Dashboard](../admin-dashboard.md) — the
+- [Admin Billing Dashboard](../admin-dashboard) — the
   site-admin `/api/v1/dashboard/*` routes: licensed users, their clusters,
   per-cluster licenses and licensed products, resource/event histories, marketplace
   subscriptions, and system-outage records.
-- [User Billing Dashboard](../user-dashboard.md) — the
+- [User Billing Dashboard](../user-dashboard) — the
   owner-scoped `/api/v1/dashboard/clusters/*` routes (`view:contracts`): an
   organization's own active clusters, licenses, licensed products, and event counts.
-- [Usage Reports](../usage-reports.md) — the
+- [Usage Reports](../usage-reports) — the
   `/api/v1/dashboard/summary/*` monthly usage-report views and PDF download, plus
   the `/api/v1/dbaas/billing/*` namespace billing reports.

--- a/docs/platform/api/billing-dashboard/overview.md
+++ b/docs/platform/api/billing-dashboard/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-billing-dashboard-readme
+    identifier: api-billing-dashboard-overview
     name: Overview
     parent: api-billing-dashboard
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/billing-dashboard/
-aliases:
-- /docs/platform/{{.version}}/api/billing-dashboard/overview/
 ---
 
 # Billing Dashboard

--- a/docs/platform/api/chart-repositories/overview.md
+++ b/docs/platform/api/chart-repositories/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-chart-repositories-readme
+    identifier: api-chart-repositories-overview
     name: Overview
     parent: api-chart-repositories
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/chart-repositories/
-aliases:
-- /docs/platform/{{.version}}/api/chart-repositories/overview/
 ---
 
 # Chart Repositories

--- a/docs/platform/api/chart-repositories/overview.md
+++ b/docs/platform/api/chart-repositories/overview.md
@@ -33,6 +33,6 @@ role is required. Only `GET` requests are exposed here.
 
 ## Pages
 
-- [Chart Repositories](../chart-repositories.md) — list the
+- [Chart Repositories](../chart-repositories) — list the
   known chart repositories, list the charts inside a repository, and list the
   versions of a named chart.

--- a/docs/platform/api/client-organizations/overview.md
+++ b/docs/platform/api/client-organizations/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-client-organizations-readme
+    identifier: api-client-organizations-overview
     name: Overview
     parent: api-client-organizations
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/client-organizations/
-aliases:
-- /docs/platform/{{.version}}/api/client-organizations/overview/
 ---
 
 # Client Organizations

--- a/docs/platform/api/client-organizations/overview.md
+++ b/docs/platform/api/client-organizations/overview.md
@@ -19,11 +19,11 @@ user access on behalf of each client.
 
 There are two concerns, split across two pages:
 
-- [Client Org Management](../management.md) — site-admin
+- [Client Org Management](../management) — site-admin
   lifecycle of client organizations: list/get/create/delete client orgs, add or
   remove clusters, and query client-org status. Routes live under
   `/api/v1/user/client*`.
-- [Cluster User Permissions](../cluster-user-permissions.md)
+- [Cluster User Permissions](../cluster-user-permissions)
   — organization-admin management of the OCM users belonging to a client org on
   a specific cluster: list users, create a user with permissions, inspect and
   update permissions, generate a kubeconfig, and remove a user. Routes live
@@ -53,5 +53,5 @@ For managed-service providers: site admins create "client orgs" and manage per-c
 
 ## Pages
 
-- [Management](../management.md)
-- [Cluster user permissions](../cluster-user-permissions.md)
+- [Management](../management)
+- [Cluster user permissions](../cluster-user-permissions)

--- a/docs/platform/api/cloud-providers/overview.md
+++ b/docs/platform/api/cloud-providers/overview.md
@@ -47,6 +47,6 @@ cloud credentials.
 
 ## Pages
 
-- [Cloud Providers](../cloud-providers.md) — the public provider
+- [Cloud Providers](../cloud-providers) — the public provider
   list, CAPI cluster provisioning, and per-provider discovery for GKE, AKS, EKS,
   DigitalOcean, Linode, Rancher, Hetzner, and KubeVirt.

--- a/docs/platform/api/cloud-providers/overview.md
+++ b/docs/platform/api/cloud-providers/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-cloud-providers-readme
+    identifier: api-cloud-providers-overview
     name: Overview
     parent: api-cloud-providers
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/cloud-providers/
-aliases:
-- /docs/platform/{{.version}}/api/cloud-providers/overview/
 ---
 
 # Cloud Providers

--- a/docs/platform/api/cluster-management-v1/overview.md
+++ b/docs/platform/api/cluster-management-v1/overview.md
@@ -96,15 +96,15 @@ Generic passthrough for any group/version/resource, powering the KubeDB Platform
 
 ## Pages
 
-- [Cluster Lifecycle & Info](../lifecycle.md) — get, update, and
+- [Cluster Lifecycle & Info](../lifecycle) — get, update, and
   delete a cluster; fetch its kubeconfig; discover available resource types; database
   status/bundle; feature values; execute whitelisted commands; create resources;
   install/uninstall deploy orders; and read resource history.
-- [Kubernetes Proxy](../kubernetes-proxy.md) — the generic
+- [Kubernetes Proxy](../kubernetes-proxy) — the generic
   `/proxy/*` passthrough for any Kubernetes group/version/resource (CRUD, status,
   events, controller, scale, HPAs), plus pod logs/exec, node/pod metrics, access
   reviews, the `meta.k8s.appscode.com` render endpoints, scanner/policy reports, and
   batch delete.
-- [Helm](../helm.md) — Helm console (tiller) configuration, Helm
+- [Helm](../helm) — Helm console (tiller) configuration, Helm
   v3 release management (list/install/upgrade/uninstall/rollback, content, status,
   history), bundle/package views, and the resource editor.

--- a/docs/platform/api/cluster-management-v1/overview.md
+++ b/docs/platform/api/cluster-management-v1/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-cluster-management-v1-readme
+    identifier: api-cluster-management-v1-overview
     name: Overview
     parent: api-cluster-management-v1
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/cluster-management-v1/
-aliases:
-- /docs/platform/{{.version}}/api/cluster-management-v1/overview/
 ---
 
 # Cluster Management v1

--- a/docs/platform/api/cluster-management-v2/overview.md
+++ b/docs/platform/api/cluster-management-v2/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-cluster-management-v2-readme
+    identifier: api-cluster-management-v2-overview
     name: Overview
     parent: api-cluster-management-v2
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/cluster-management-v2/
-aliases:
-- /docs/platform/{{.version}}/api/cluster-management-v2/overview/
 ---
 
 # Cluster Management v2

--- a/docs/platform/api/cluster-management-v2/overview.md
+++ b/docs/platform/api/cluster-management-v2/overview.md
@@ -68,8 +68,8 @@ Related: `GET /api/v1/agent/:clusterName/:clusterID/token` (Token) — inbox age
 
 ## Pages
 
-- [Clusters](../clusters.md) — providers, hubs, cluster identity,
+- [Clusters](../clusters) — providers, hubs, cluster identity,
   listing, status, import/connect/remove, reconcile, reconfigure, Kubernetes version
   upgrades, gateway configs, feature conversion, and vclusters.
-- [Subscriptions & Inbox](../subscriptions.md) — cluster,
+- [Subscriptions & Inbox](../subscriptions) — cluster,
   namespace, and resource notification subscriptions, plus the inbox agent token.

--- a/docs/platform/api/licensing-contracts/overview.md
+++ b/docs/platform/api/licensing-contracts/overview.md
@@ -76,11 +76,11 @@ Related: `POST /api/v1/user/license-proxy` — generate the `license-proxyserver
 
 ## Pages
 
-- [License Registration](../registration.md) — `POST /register`,
+- [License Registration](../registration) — `POST /register`,
   `POST /license/issue`, `POST /user/license-proxy`.
-- [Contracts — Admin](../contracts-admin.md) — `/contracts/*`
+- [Contracts — Admin](../contracts-admin) — `/contracts/*`
   (AppsCode-hosted, site-admin).
-- [Contracts — User](../contracts-user.md) — `/user/contracts/*`
+- [Contracts — User](../contracts-user) — `/user/contracts/*`
   (AppsCode-hosted, token).
 
 ## Common concepts

--- a/docs/platform/api/licensing-contracts/overview.md
+++ b/docs/platform/api/licensing-contracts/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-licensing-contracts-readme
+    identifier: api-licensing-contracts-overview
     name: Overview
     parent: api-licensing-contracts
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/licensing-contracts/
-aliases:
-- /docs/platform/{{.version}}/api/licensing-contracts/overview/
 ---
 
 # Licensing & Contracts

--- a/docs/platform/api/marketplace/overview.md
+++ b/docs/platform/api/marketplace/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-marketplace-readme
+    identifier: api-marketplace-overview
     name: Overview
     parent: api-marketplace
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/marketplace/
-aliases:
-- /docs/platform/{{.version}}/api/marketplace/overview/
 ---
 
 # Marketplace

--- a/docs/platform/api/marketplace/overview.md
+++ b/docs/platform/api/marketplace/overview.md
@@ -53,5 +53,5 @@ GET endpoints, the observed behaviour on a non-marketplace deployment.
 
 ## Pages
 
-- [Webhook Service](../webhook-service.md) — `/marketplace/api/v1/*`: claimable check, AWS/Azure/GCP subscription notifications, and version (separate listener).
-- [Metered Billing](../metered-billing.md) — `/api/v1/proxy/metered-billing/marketplaces/*`: AWS/GCP usage reporting and readiness probes (site-admin, deployment-gated).
+- [Webhook Service](../webhook-service) — `/marketplace/api/v1/*`: claimable check, AWS/Azure/GCP subscription notifications, and version (separate listener).
+- [Metered Billing](../metered-billing) — `/api/v1/proxy/metered-billing/marketplaces/*`: AWS/GCP usage reporting and readiness probes (site-admin, deployment-gated).

--- a/docs/platform/api/miscellaneous/overview.md
+++ b/docs/platform/api/miscellaneous/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-miscellaneous-readme
+    identifier: api-miscellaneous-overview
     name: Overview
     parent: api-miscellaneous
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/miscellaneous/
-aliases:
-- /docs/platform/{{.version}}/api/miscellaneous/overview/
 ---
 
 # Miscellaneous

--- a/docs/platform/api/miscellaneous/overview.md
+++ b/docs/platform/api/miscellaneous/overview.md
@@ -34,7 +34,7 @@ account activation & recovery, 2FA/WebAuthn login, and static assets.
 
 ## Pages
 
-- [Miscellaneous Endpoints](../miscellaneous.md) — server version
+- [Miscellaneous Endpoints](../miscellaneous) — server version
   (`/api/v1/version`), markdown rendering (`/api/v1/markdown`, `/api/v1/markdown/raw`),
   the Swagger UI (`/api/v1/swagger`), the health check (`/healthz`), and OIDC discovery
   (`/.well-known/openid-configuration`).

--- a/docs/platform/api/monitoring-telemetry/overview.md
+++ b/docs/platform/api/monitoring-telemetry/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-monitoring-telemetry-readme
+    identifier: api-monitoring-telemetry-overview
     name: Overview
     parent: api-monitoring-telemetry
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/monitoring-telemetry/
-aliases:
-- /docs/platform/{{.version}}/api/monitoring-telemetry/overview/
 ---
 
 # Monitoring & Telemetry API

--- a/docs/platform/api/monitoring-telemetry/overview.md
+++ b/docs/platform/api/monitoring-telemetry/overview.md
@@ -51,9 +51,9 @@ KubeDB Platform. It has two surfaces:
 
 ## Pages
 
-- [Telemetry Stack](../telemetry-stack.md) — list monitoring
+- [Telemetry Stack](../telemetry-stack) — list monitoring
   clusters, install the telemetry stack, fetch `appscode-otel-stack` Helm values, get the
   stack host, and list tenant owners.
-- [Trickster Auth Proxy](../trickster.md) — register/unregister
+- [Trickster Auth Proxy](../trickster) — register/unregister
   Prometheus backends for Grafana and Perses datasources, and the `prom-authproxy`
   ownership check.

--- a/docs/platform/api/multicluster-ocm/overview.md
+++ b/docs/platform/api/multicluster-ocm/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-multicluster-ocm-readme
+    identifier: api-multicluster-ocm-overview
     name: Overview
     parent: api-multicluster-ocm
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/multicluster-ocm/
-aliases:
-- /docs/platform/{{.version}}/api/multicluster-ocm/overview/
 ---
 
 # Multi-cluster (OCM)

--- a/docs/platform/api/multicluster-ocm/overview.md
+++ b/docs/platform/api/multicluster-ocm/overview.md
@@ -61,13 +61,13 @@ All require Token + org/user resolution + cluster mapping.
 
 ## Pages
 
-- [Hubs & Spokes](../hubs-spokes.md) — list hub clusters, inspect
+- [Hubs & Spokes](../hubs-spokes) — list hub clusters, inspect
   spoke inventories (managed / accepted / not-accepted / available), accept spoke
   join requests, generate the spoke install command, import or convert a cluster to
   a spoke, remove a managed cluster, validate profiles, and sync account objects.
-- [Cluster Sets & Feature Sets](../cluster-sets.md) — create,
+- [Cluster Sets & Feature Sets](../cluster-sets) — create,
   delete, and populate cluster sets; install/disable/update feature sets; check
   feature sync status and auto-update; and bind namespaces to cluster sets.
-- [OCM Users](../ocm-users.md) — list, create, inspect, update, and
+- [OCM Users](../ocm-users) — list, create, inspect, update, and
   delete OCM users and their per-cluster / per-cluster-set permissions, and fetch a
   user's kubeconfig for a spoke cluster.

--- a/docs/platform/api/organizations-teams/overview.md
+++ b/docs/platform/api/organizations-teams/overview.md
@@ -57,10 +57,10 @@ role-based permissions (all checks are OpenFGA-backed).
 
 ## Pages
 
-- [Organizations](../organizations.md) — the `/api/v1/orgs/*`
+- [Organizations](../organizations) — the `/api/v1/orgs/*`
   endpoints: create/claim organizations, get/edit/delete an org, ownership and
   membership checks, member management, avatars, Rancher sync/user tokens, and org
   access/NATS tokens.
-- [Teams](../teams.md) — the `/api/v1/orgs/{orgname}/teams` and
+- [Teams](../teams) — the `/api/v1/orgs/{orgname}/teams` and
   `/api/v1/teams/{teamid}/*` endpoints: list/create teams, team actions, and team
   member management.

--- a/docs/platform/api/organizations-teams/overview.md
+++ b/docs/platform/api/organizations-teams/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-organizations-teams-readme
+    identifier: api-organizations-teams-overview
     name: Overview
     parent: api-organizations-teams
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/organizations-teams/
-aliases:
-- /docs/platform/{{.version}}/api/organizations-teams/overview/
 ---
 
 # Identity: Organizations & Teams

--- a/docs/platform/api/rancher/overview.md
+++ b/docs/platform/api/rancher/overview.md
@@ -41,5 +41,5 @@ token.
 
 ## Pages
 
-- [Rancher Integration](../rancher.md) — user sync, acerproxy install
+- [Rancher Integration](../rancher) — user sync, acerproxy install
   command, CA download, proxy-server token, and NATS credentials.

--- a/docs/platform/api/rancher/overview.md
+++ b/docs/platform/api/rancher/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-rancher-readme
+    identifier: api-rancher-overview
     name: Overview
     parent: api-rancher
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/rancher/
-aliases:
-- /docs/platform/{{.version}}/api/rancher/overview/
 ---
 
 # Rancher Integration API

--- a/docs/platform/api/users-settings/overview.md
+++ b/docs/platform/api/users-settings/overview.md
@@ -2,15 +2,12 @@
 layout: docs
 menu:
   docsplatform_{{.version}}:
-    identifier: api-users-settings-readme
+    identifier: api-users-settings-overview
     name: Overview
     parent: api-users-settings
     weight: 1
 menu_name: docsplatform_{{.version}}
 section_menu_id: api
-url: /docs/platform/{{.version}}/api/users-settings/
-aliases:
-- /docs/platform/{{.version}}/api/users-settings/overview/
 ---
 
 # Identity: Users & Settings

--- a/docs/platform/api/users-settings/overview.md
+++ b/docs/platform/api/users-settings/overview.md
@@ -98,13 +98,13 @@ through these endpoints authenticate the token-guarded REST API.
 
 ## Pages
 
-- [Public & Basic-auth User APIs](../public-user-apis.md) — public
+- [Public & Basic-auth User APIs](../public-user-apis) — public
   user lookup/search, a user's organizations, social follow info, HTTP Basic-auth
   token management, and sign-in.
-- [Authenticated User](../authenticated-user.md) — the
+- [Authenticated User](../authenticated-user) — the
   `/api/v1/user/*` endpoints: the current user, emails, NATS credentials, cloud
   credentials, clusters, teams, organizations, and name/email validation.
-- [User Settings](../user-settings.md) — the
+- [User Settings](../user-settings) — the
   `/api/v1/user/settings/*` endpoints: profile and avatar, password and account
   emails, 2FA and WebAuthn security, sessions, personal access and NATS tokens, and
   OAuth2 applications.


### PR DESCRIPTION
## Problem

The "Pages" links on every API section overview 404 on the live site (reported for `multicluster-ocm`, but affects all sections).

**Root cause:** each `api/<section>/README.md` overrides `url:` to the section root (`/api/<section>/`), one level shallower than a normal leaf page. The repo's intentional extra-`../` link convention is calibrated for leaf pages at `/api/<section>/<leaf>/`, so a `../<leaf>.md` link from a section-root page climbs to `/api/<leaf>/` → 404.

## Fix

Convert all API subsection READMEs to the proven working leaf pattern used by `guides/*/overview.md`:

- `README.md` → `overview.md`
- drop the `url:` override and the `aliases:` block
- rename menu identifier `api-<section>-readme` → `api-<section>-overview`
- body links unchanged — they now resolve correctly from `/api/<section>/overview/`

Section roots (`/api/<section>/`) now fall back to the empty `_index.md` auto-list, same as `guides/*`.

The top-level `api/README.md` stays the `/api/` landing; its 18 numbered-table links are repointed `../api/<section>/` → `../api/<section>/overview/` to land on the overview content.

## Verification

- All 18 table targets resolve to real `overview.md` files.
- Every `../…` body link in the converted overviews passes CI's strip-one-`../` check (0 broken).
- Structure now matches the proven `guides` overview pattern.